### PR TITLE
45 enable custom axis titles

### DIFF
--- a/R/indicator_introduction_year.R
+++ b/R/indicator_introduction_year.R
@@ -54,7 +54,9 @@ indicator_introduction_year <- function(df, start_year_plot = 1920,
                                         x_major_scale_stepsize = 10,
                                         x_minor_scale_stepsize = 5,
                                         facet_column = NULL,
-                                        first_observed = "first_observed") {
+                                        first_observed = "first_observed",
+                                        x_lab = "Year",
+                                        y_lab = "Number of introduced alien species") {
   # initial input checks
   assert_that(is.data.frame(df))
   assert_colnames(df, c(first_observed), only_colnames = FALSE)

--- a/R/indicator_introduction_year.R
+++ b/R/indicator_introduction_year.R
@@ -39,7 +39,17 @@
 #'   "https://raw.githubusercontent.com/trias-project/pipeline/master/data/",
 #'   "interim/test_data_output_checklist_indicators.tsv"
 #' )
-#' data <- read_tsv(datafile)
+#' data <- read_tsv(datafile, 
+#'                  na = "NA", 
+#'                  col_types = cols(
+#'                    .default = col_character(),
+#'                    key = col_double(),
+#'                    nubKey = col_double(),
+#'                    speciesKey = col_double(),
+#'                    acceptedKey = col_double(),
+#'                    first_observed = col_double(),
+#'                    last_observed = col_double()
+#'                  ))
 #' # without facets
 #' indicator_introduction_year(data)
 #' # specify start year and smoother parameter
@@ -49,7 +59,9 @@
 #' indicator_introduction_year(data, facet_column = "kingdom")
 #' # specifiy columns with year of first observed
 #' indicator_introduction_year(data,
-#'                             first_observed = "first_oberved")
+#'                             first_observed = "first_observed")
+#' # specify axis labels
+#' indicator_introduction_year(data, x_lab = "YEAR", y_lab = NULL)
 #' }
 indicator_introduction_year <- function(df, start_year_plot = 1920,
                                         smooth_span = .85,

--- a/R/indicator_introduction_year.R
+++ b/R/indicator_introduction_year.R
@@ -19,6 +19,8 @@
 #'   NULL.
 #' @param first_observed character. Name of the column of \code{df} containing
 #'   information about year of introduction. Default: \code{first_observed}.
+#' @param x_lab NULL or character. to set or remove the x-axis label.
+#' @param y_lab NULL or character. to set or remove the y-axis label.
 #'
 #' @return A ggplot2 object (or egg object if facets are used).
 #'
@@ -81,8 +83,8 @@ indicator_introduction_year <- function(df, start_year_plot = 1920,
   top_graph <- ggplot(data_top_graph, aes(x = first_observed, y = n)) +
     geom_point(stat = "identity") +
     geom_smooth(span = smooth_span) +
-    xlab("Year") +
-    ylab("Number of introduced alien species") +
+    xlab(x_lab) +
+    ylab(y_lab) +
     scale_x_continuous(
       breaks = seq(
         start_year_plot,
@@ -121,8 +123,8 @@ indicator_introduction_year <- function(df, start_year_plot = 1920,
       geom_point(stat = "identity") +
       geom_smooth(span = smooth_span) +
       facet_wrap(facet_column) +
-      xlab("Year") +
-      ylab("Number of introduced alien species") +
+      xlab(x_lab) +
+      ylab(y_lab) +
       scale_x_continuous(
         breaks = seq(
           start_year_plot,

--- a/R/indicator_total_year.R
+++ b/R/indicator_total_year.R
@@ -21,6 +21,8 @@
 #'   introduction or \code{"habitat"}.
 #' @param first_observed character. Name of the column of \code{df} containing
 #'   information about year of introduction. Default: \code{"first_observed"}.
+#' @param x_lab NULL or character. to set or remove the x-axis label.
+#' @param y_lab NULL or character. to set or remove the y-axis label.
 #'
 #' @return ggplot2 object (or egg object if facets are used).
 #'
@@ -56,7 +58,9 @@ indicator_total_year <- function(df, start_year_plot = 1940,
                                  x_major_scale_stepsize = 10,
                                  x_minor_scale_stepsize = 5,
                                  facet_column = NULL,
-                                 first_observed = "first_observed") {
+                                 first_observed = "first_observed",
+                                 x_lab = "Year",
+                                 y_lab = "Cumulative number of alien species") {
 
   # initial input checks
   assert_that(is.data.frame(df))
@@ -104,8 +108,8 @@ indicator_total_year <- function(df, start_year_plot = 1940,
   maxDate <- max(df_extended$year)
   top_graph <- ggplot(df_extended, aes(x = year)) +
     geom_line(stat = "count") +
-    xlab("Year") +
-    ylab("Cumulative number of alien species") +
+    xlab(x_lab) +
+    ylab(y_lab) +
     scale_x_continuous(
       breaks = seq(
         start_year_plot, maxDate,
@@ -136,8 +140,8 @@ indicator_total_year <- function(df, start_year_plot = 1940,
       aes(x = year, y = n)
     ) +
       geom_line(stat = "identity") +
-      xlab("Year") +
-      ylab("Cumulative number of alien species") +
+      xlab(x_lab) +
+      ylab(y_lab) +
       facet_wrap(facet_column) +
       scale_x_continuous(
         breaks = seq(start_year_plot, maxDate, x_major_scale_stepsize),

--- a/R/indicator_total_year.R
+++ b/R/indicator_total_year.R
@@ -43,7 +43,17 @@
 #'   "https://raw.githubusercontent.com/trias-project/pipeline/master/data/",
 #'   "interim/test_data_output_checklist_indicators.tsv"
 #' )
-#' data <- read_tsv(datafile)
+#' data <- read_tsv(datafile, 
+#'                  na = "NA", 
+#'                  col_types = cols(
+#'                    .default = col_character(),
+#'                    key = col_double(),
+#'                    nubKey = col_double(),
+#'                    speciesKey = col_double(),
+#'                    acceptedKey = col_double(),
+#'                    first_observed = col_double(),
+#'                    last_observed = col_double()
+#'                  ))
 #' start_year_plot <- 1900
 #' x_major_scale_stepsize <- 25
 #' x_minor_scale_stepsize <- 5
@@ -53,6 +63,8 @@
 #' indicator_total_year(data, start_year_plot, facet_column = "phylum")
 #' # specify name of column containing year of introduction (first_observed)
 #' indicator_total_year(data, first_observed = "first_observed")
+#' # specify axis labels
+#' indicator_total_year(data, x_lab = "YEAR", y_lab = NULL)
 #' }
 indicator_total_year <- function(df, start_year_plot = 1940,
                                  x_major_scale_stepsize = 10,

--- a/man/indicator_introduction_year.Rd
+++ b/man/indicator_introduction_year.Rd
@@ -52,7 +52,17 @@ datafile <- paste0(
   "https://raw.githubusercontent.com/trias-project/pipeline/master/data/",
   "interim/test_data_output_checklist_indicators.tsv"
 )
-data <- read_tsv(datafile)
+data <- read_tsv(datafile, 
+                 na = "NA", 
+                 col_types = cols(
+                   .default = col_character(),
+                   key = col_double(),
+                   nubKey = col_double(),
+                   speciesKey = col_double(),
+                   acceptedKey = col_double(),
+                   first_observed = col_double(),
+                   last_observed = col_double()
+                 ))
 # without facets
 indicator_introduction_year(data)
 # specify start year and smoother parameter
@@ -62,6 +72,8 @@ indicator_introduction_year(data, start_year_plot = 1940,
 indicator_introduction_year(data, facet_column = "kingdom")
 # specifiy columns with year of first observed
 indicator_introduction_year(data,
-                            first_observed = "first_oberved")
+                            first_observed = "first_observed")
+# specify axis labels
+indicator_introduction_year(data, x_lab = "YEAR", y_lab = NULL)
 }
 }

--- a/man/indicator_introduction_year.Rd
+++ b/man/indicator_introduction_year.Rd
@@ -7,7 +7,8 @@
 indicator_introduction_year(df, start_year_plot = 1920,
   smooth_span = 0.85, x_major_scale_stepsize = 10,
   x_minor_scale_stepsize = 5, facet_column = NULL,
-  first_observed = "first_observed")
+  first_observed = "first_observed", x_lab = "Year",
+  y_lab = "Number of introduced alien species")
 }
 \arguments{
 \item{df}{A data frame.}
@@ -33,6 +34,10 @@ NULL.}
 
 \item{first_observed}{character. Name of the column of \code{df} containing
 information about year of introduction. Default: \code{first_observed}.}
+
+\item{x_lab}{NULL or character. to set or remove the x-axis label.}
+
+\item{y_lab}{NULL or character. to set or remove the y-axis label.}
 }
 \value{
 A ggplot2 object (or egg object if facets are used).

--- a/man/indicator_total_year.Rd
+++ b/man/indicator_total_year.Rd
@@ -53,7 +53,17 @@ datafile <- paste0(
   "https://raw.githubusercontent.com/trias-project/pipeline/master/data/",
   "interim/test_data_output_checklist_indicators.tsv"
 )
-data <- read_tsv(datafile)
+data <- read_tsv(datafile, 
+                 na = "NA", 
+                 col_types = cols(
+                   .default = col_character(),
+                   key = col_double(),
+                   nubKey = col_double(),
+                   speciesKey = col_double(),
+                   acceptedKey = col_double(),
+                   first_observed = col_double(),
+                   last_observed = col_double()
+                 ))
 start_year_plot <- 1900
 x_major_scale_stepsize <- 25
 x_minor_scale_stepsize <- 5
@@ -63,5 +73,7 @@ indicator_total_year(data, start_year_plot, x_major_scale_stepsize)
 indicator_total_year(data, start_year_plot, facet_column = "phylum")
 # specify name of column containing year of introduction (first_observed)
 indicator_total_year(data, first_observed = "first_observed")
+# specify axis labels
+indicator_total_year(data, x_lab = "YEAR", y_lab = NULL)
 }
 }

--- a/man/indicator_total_year.Rd
+++ b/man/indicator_total_year.Rd
@@ -6,7 +6,8 @@
 \usage{
 indicator_total_year(df, start_year_plot = 1940,
   x_major_scale_stepsize = 10, x_minor_scale_stepsize = 5,
-  facet_column = NULL, first_observed = "first_observed")
+  facet_column = NULL, first_observed = "first_observed",
+  x_lab = "Year", y_lab = "Cumulative number of alien species")
 }
 \arguments{
 \item{df}{df. Contains the data as produced by the Trias pipeline,
@@ -32,6 +33,10 @@ introduction or \code{"habitat"}.}
 
 \item{first_observed}{character. Name of the column of \code{df} containing
 information about year of introduction. Default: \code{"first_observed"}.}
+
+\item{x_lab}{NULL or character. to set or remove the x-axis label.}
+
+\item{y_lab}{NULL or character. to set or remove the y-axis label.}
 }
 \value{
 ggplot2 object (or egg object if facets are used).


### PR DESCRIPTION
As requested in issues #45 I added 2 variables that enable users to set custom axis titles for graphs produced by the [indicator_introduction_year.R](https://github.com/trias-project/trias/blob/master/R/indicator_introduction_year.R) and [indicator_total_year.R](https://github.com/trias-project/trias/blob/master/R/indicator_total_year.R) indicators. 