### PR TITLE
Patch to solve bug in pathwaycbd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species (TrIAS)
-Version: 1.2.0.9000
+Version: 1.2.1.9000
 Description: TrIAS provides functionality to facilitate the data processing 
     for the project Tracking Invasive Alien Species (TrIAS 
     <http://trias-project.be>).

--- a/R/pathways_cbd.R
+++ b/R/pathways_cbd.R
@@ -71,7 +71,7 @@ pathwayscbd <- tibble(
     "water",
     "land",
     "unknown",
-    "dispersal",
+    "natural_dispersal",
     "unknown",
     "unknown"
   )


### PR DESCRIPTION
While working on pathway indicator, I found that the pathway level 2 `dispersal` in `pathwayscbd` data.frame, is wrong. It is `natural_dispersal`.
This PR is just a patch for solving this bug.