### PR TITLE
Solve bug visualize pathway getting empty df

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species (TrIAS)
-Version: 1.2.1.9000
+Version: 1.2.2.9000
 Description: TrIAS provides functionality to facilitate the data processing 
     for the project Tracking Invasive Alien Species (TrIAS 
     <http://trias-project.be>).

--- a/R/visualize_pathways_level1.R
+++ b/R/visualize_pathways_level1.R
@@ -47,7 +47,8 @@
 #' @export
 #' @importFrom assertthat assert_that
 #' @importFrom assertable assert_colnames
-#' @importFrom dplyr %>% anti_join distinct filter mutate pull rename_at sym
+#' @importFrom dplyr %>% anti_join distinct filter if_else mutate pull rename_at
+#'   sym
 #' @importFrom ggplot2 ggplot geom_bar theme ggtitle xlab ylab coord_flip
 #'   facet_wrap
 #' @importFrom tidyselect all_of
@@ -288,7 +289,7 @@ visualize_pathways_level1 <- function(df,
   df <-
     df %>%
     # Handle NAs and "unknown"
-    mutate(pathway_level1 = ifelse(is.na(.data$pathway_level1) |
+    mutate(pathway_level1 = if_else(is.na(.data$pathway_level1) |
       .data$pathway_level1 == "",
     "unknown",
     .data$pathway_level1

--- a/R/visualize_pathways_level2.R
+++ b/R/visualize_pathways_level2.R
@@ -52,7 +52,8 @@
 #' @export
 #' @importFrom assertthat assert_that
 #' @importFrom assertable assert_colnames
-#' @importFrom dplyr %>% anti_join distinct filter mutate pull rename_at sym
+#' @importFrom dplyr %>% anti_join distinct filter if_else mutate pull rename_at
+#'   sym
 #' @importFrom ggplot2 ggplot geom_bar theme ggtitle xlab ylab coord_flip
 #'   facet_wrap
 #' @importFrom tidyselect all_of
@@ -338,7 +339,7 @@ visualize_pathways_level2 <- function(df,
   df <-
     df %>%
     # Handle NAs and "unknown"
-    mutate(pathway_level2 = ifelse(is.na(.data$pathway_level2) |
+    mutate(pathway_level2 = if_else(is.na(.data$pathway_level2) |
       .data$pathway_level2 == "",
     "unknown",
     .data$pathway_level2

--- a/tests/testthat/test-visualize_pathways_level1.R
+++ b/tests/testthat/test-visualize_pathways_level1.R
@@ -72,6 +72,12 @@ output_less_pathways_inverted <- visualize_pathways_level1(
   pathways = pathways_selection_inverted
 )
 
+empty_output <- visualize_pathways_level1(
+  input_test_df %>%
+    filter(kingdom != "Protozoa" | pathway_level1 != "unknown"),
+  category = "Protozoa"
+)
+
 testthat::test_that("Argument: df", {
   expect_error(
     visualize_pathways_level1(3),
@@ -268,14 +274,18 @@ testthat::test_that("Test empty pathway_level1 transformation to unknown", {
 testthat::test_that("Test output class", {
   expect_type(output_general, type = "list")
   expect_type(output_with_facet, type = "list")
+  expect_type(empty_output, type = "list")
   expect_s3_class(output_general, class = "gg")
   expect_s3_class(output_with_facet, class = "egg")
+  expect_s3_class(empty_output, class = "gg")
 })
 
 testthat::test_that("test pathway factors and their order", {
   expect_true(is.factor(output_general$data$pathway_level1))
   expect_true(is.factor(output_less_pathways$data$pathway_level1))
   expect_true(is.factor(output_less_pathways_inverted$data$pathway_level1))
+  expect_true(is.factor(empty_output$data$pathway_level1))
+  expect_true(nrow(empty_output$data) == 0)
   expect_true(all(levels(output_general$data$pathway_level1) ==
     valid_pathways))
   expect_true(all(levels(output_less_pathways$data$pathway_level1) ==

--- a/tests/testthat/test-visualize_pathways_level2.R
+++ b/tests/testthat/test-visualize_pathways_level2.R
@@ -10,6 +10,7 @@ input_test_df <- read.delim(
   stringsAsFactors = FALSE
 )
 
+
 valid_pathways_escape <-
   pathways_cbd() %>%
   filter(pathway_level1 == "escape") %>%
@@ -85,6 +86,13 @@ output_less_pathways_inverted_escape <- visualize_pathways_level2(
   input_test_df,
   chosen_pathway_level1 = "escape",
   pathways = pathways_selection_inverted_escape
+)
+
+empty_output <- visualize_pathways_level2(
+  input_test_df %>% # filter to be sure to produce empty bar plot
+    filter(kingdom != "Protozoa" | pathway_level1 != "corridor"),
+  chosen_pathway_level1 = "corridor",
+  category = "Protozoa"
 )
 
 testthat::test_that("Argument: df", {
@@ -354,14 +362,18 @@ testthat::test_that("Test empty pathway_level1 transformation to unknown", {
 testthat::test_that("Test output class", {
   expect_type(output_general, type = "list")
   expect_type(output_with_facet, type = "list")
+  expect_type(empty_output, type = "list")
   expect_s3_class(output_general, class = "gg")
   expect_s3_class(output_with_facet, class = "egg")
+  expect_s3_class(empty_output, class = "gg")
 })
 
 testthat::test_that("test pathway factors and their order", {
   expect_true(is.factor(output_general$data$pathway_level2))
   expect_true(is.factor(output_less_pathways_escape$data$pathway_level2))
   expect_true(is.factor(output_less_pathways_inverted_escape$data$pathway_level2))
+  expect_true(is.factor(empty_output$data$pathway_level2))
+  expect_true(nrow(empty_output$data) == 0)
   expect_true(all(levels(output_general$data$pathway_level2) ==
     valid_pathways_escape))
   expect_true(all(levels(output_less_pathways_escape$data$pathway_level2) ==


### PR DESCRIPTION
This PR solves a bug which occurs in `visualize_pathways_level1` and `visualize_pathways_level2` when the input df is not empty but it gets empty due to restrictions on `category` or `from`.
This was due to the use of `ifelse` in a `mutate()` which changes `NA_character` to NA (logical) if there are no rows. Using `if_else` from dplyr solves the problem.

Unit-tests are added and patch number is updated in version of the pakage.