### PR TITLE
Replace deprecated arg readr

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,7 +28,6 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
           - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/update_download_list.R
+++ b/R/update_download_list.R
@@ -93,7 +93,7 @@ update_download_list <- function(file, download_to_add, input_checklist,
     readr::write_tsv(
       x = downloads,
       file = file,
-      quote_escape = FALSE
+      escape = "none"
     )
   }
 }

--- a/R/update_download_list.R
+++ b/R/update_download_list.R
@@ -54,7 +54,7 @@ update_download_list <- function(file, download_to_add, input_checklist,
       na = "",
       append = TRUE,
       col_names = !file.exists(file),
-      quote_escape = FALSE
+      escape = "none"
     )
     print(paste(
       "gbif_download_Key", download_to_add,

--- a/R/update_download_list.R
+++ b/R/update_download_list.R
@@ -93,6 +93,7 @@ update_download_list <- function(file, download_to_add, input_checklist,
     readr::write_tsv(
       x = downloads,
       file = file,
+      na = "",
       escape = "none"
     )
   }

--- a/tests/testthat/test-input_gbif_get_taxa.R
+++ b/tests/testthat/test-input_gbif_get_taxa.R
@@ -76,15 +76,15 @@ testthat::test_that("Limit is a number", {
 testthat::test_that("taxon_keys not found in GBIF, error from rgbif", {
   expect_error(
     gbif_get_taxa(taxon_keys = 103451),
-    "Not Found"
+    "Entity not found for uri: /"
   )
   expect_error(
     gbif_get_taxa(taxon_keys = "103451"),
-    "Not Found"
+    "Entity not found for uri: /"
   )
   expect_error(
     gbif_get_taxa(taxon_keys = c(2, 103451)),
-    "Not Found"
+    "Entity not found for uri: /"
   )
 })
 


### PR DESCRIPTION
This PR replaces deprecated arg `quote_escape = FALSE` with `escape = "none"` in call of `write_tsv()` within function `udpate_download_list()`.