### PR TITLE
Adapt code to use gratia

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species
     (TrIAS)
-Version: 2.0.8
+Version: 2.1.0
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/apply_decision_rules.R
+++ b/R/apply_decision_rules.R
@@ -228,7 +228,7 @@ apply_decision_rules <- function(df,
       last_occ = max(.data$last_occ)
     ) %>%
     dplyr::mutate(dr_2 = .data$last_occ > .data$median_occ) %>%
-    dplyr::select(!!rlang::sym(taxonKey), dr_2)
+    dplyr::select(!!rlang::sym(taxonKey), "dr_2")
 
   # Rule 3: 0 in the last 5 years?
   dr_3 <-
@@ -237,7 +237,7 @@ apply_decision_rules <- function(df,
     dplyr::filter(!!rlang::sym(year) > (max(!!rlang::sym(year)) - 5)) %>%
     dplyr::tally(!!rlang::sym(y_var)) %>%
     dplyr::mutate(dr_3 = n == 0) %>%
-    dplyr::select(!!rlang::sym(taxonKey), dr_3)
+    dplyr::select(!!rlang::sym(taxonKey), "dr_3")
 
   # Rule 4: last value (at eval_year) is the maximum ever observed?
   dr_4 <-
@@ -251,7 +251,7 @@ apply_decision_rules <- function(df,
     by = taxonKey
     ) %>%
     dplyr::mutate(dr_4 = .data$last_value == .data$max_occ) %>%
-    dplyr::select(!!rlang::sym(taxonKey), dr_4)
+    dplyr::select(!!rlang::sym(taxonKey), "dr_4")
 
   # Join all decision rules together
   dr_all <-
@@ -282,11 +282,11 @@ apply_decision_rules <- function(df,
     dplyr::select(
       !!rlang::sym(taxonKey),
       !!rlang::sym(year),
-      em_status,
-      dr_1,
-      dr_2,
-      dr_3,
-      dr_4
+      "em_status",
+      "dr_1",
+      "dr_2",
+      "dr_3",
+      "dr_4"
     ) %>%
     dplyr::as_tibble()
 

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -270,14 +270,14 @@ apply_gam <- function(df,
   if (is.numeric(taxon_key)) {
     taxon_key <- as.character(taxon_key)
   }
-
+  
   # Check right type of inputs
   assertthat::assert_that(is.data.frame(df),
-    msg = paste(
-      paste(as.character(df), collapse = ","),
-      "is not a data frame.",
-      "Check value of argument df."
-    )
+                          msg = paste(
+                            paste(as.character(df), collapse = ","),
+                            "is not a data frame.",
+                            "Check value of argument df."
+                          )
   )
   purrr::map2(
     list(y_var, year, taxonKey, type_indicator, x_label, y_label),
@@ -285,85 +285,85 @@ apply_gam <- function(df,
     function(x, y) {
       # Check right type of inputs
       assertthat::assert_that(is.character(x),
-        msg = paste0(
-          paste(as.character(x), collapse = ","),
-          " is not a character vector.",
-          " Check value of argument ", y, "."
-        )
+                              msg = paste0(
+                                paste(as.character(x), collapse = ","),
+                                " is not a character vector.",
+                                " Check value of argument ", y, "."
+                              )
       )
       # Check y_var, year, taxonKey, type_indicator have length 1
       assertthat::assert_that(length(x) == 1,
-        msg = paste0(
-          "Multiple values for argument ",
-          paste0(y, collapse = ","),
-          " provided."
-        )
+                              msg = paste0(
+                                "Multiple values for argument ",
+                                paste0(y, collapse = ","),
+                                " provided."
+                              )
       )
     }
   )
   assertthat::assert_that(is.numeric(eval_years),
-    msg = paste(
-      paste(as.character(eval_years), collapse = ","),
-      "is not a numeric or integer vector.",
-      "Check value of argument eval_years."
-    )
+                          msg = paste(
+                            paste(as.character(eval_years), collapse = ","),
+                            "is not a numeric or integer vector.",
+                            "Check value of argument eval_years."
+                          )
   )
-
+  
   purrr::map2(
     list(baseline_var, taxon_key, name, df_title, dir_name),
     c("baseline_var", "taxon_key", "name", "df_title", "dir_name"),
     function(x, y) {
       # check argument type
       assertthat::assert_that(is.null(x) | is.character(x),
-        msg = paste0(
-          paste(as.character(x), collapse = ","),
-          " is not a character vector.",
-          " Check value of argument ", y, "."
-        )
+                              msg = paste0(
+                                paste(as.character(x), collapse = ","),
+                                " is not a character vector.",
+                                " Check value of argument ", y, "."
+                              )
       )
       # check length
       assertthat::assert_that(length(x) < 2,
-        msg = paste(
-          "Multiple values for argument",
-          y, "provided."
-        )
+                              msg = paste(
+                                "Multiple values for argument",
+                                y, "provided."
+                              )
       )
     }
   )
-
+  
   purrr::map2(
     list(saveplot, verbose),
     c("saveplot", "verbose"),
     function(x, y) {
       assertthat::assert_that(is.logical(x),
-        msg = paste(
-          paste(as.character(x), collapse = ","),
-          "is not a logical vector.",
-          "Check value of argument saveplot.",
-          "Did you maybe use quotation marks?"
-        )
+                              msg = paste(
+                                paste(as.character(x), collapse = ","),
+                                "is not a logical vector.",
+                                "Check value of argument saveplot.",
+                                "Did you maybe use quotation marks?"
+                              )
       )
       assertthat::assert_that(length(x) == 1,
-        msg = paste("Multiple values for argument", y, "provided.")
+                              msg = paste("Multiple values for argument", y, "provided.")
       )
     }
   )
-
+  
   purrr::map2(
     list(y_var, year, taxonKey),
     c("y_var", "year", "taxonKey"),
     function(x, y) {
       # Check y_var, year, taxonKey are present in df
       assertthat::assert_that(x %in% names(df),
-        msg = paste0(
-          "The column ", x,
-          " is not present in df. Check value of",
-          " argument ", y, "."
-        )
+                              msg = paste0(
+                                "The column ", x,
+                                " is not present in df. Check value of",
+                                " argument ", y, "."
+                              )
       )
     }
   )
-
+  
   if (!is.null(baseline_var)) {
     # Check baseline_var is present in df
     assertthat::assert_that(
@@ -377,7 +377,7 @@ apply_gam <- function(df,
   } else {
     method_em <- "basic"
   }
-
+  
   if (isFALSE(saveplot)) {
     if (!is.null(dir_name)) {
       warning(paste(
@@ -393,44 +393,44 @@ apply_gam <- function(df,
       dir_name <- "./"
     }
   }
-
+  
   year <- tidyselect::vars_pull(names(df), !!dplyr::enquo(year))
   taxonKey <- tidyselect::vars_pull(names(df), !!dplyr::enquo(taxonKey))
-
+  
   # Check eval_year is present in column year
   assertthat::assert_that(all(eval_years %in% df[[year]]),
-    msg = paste(
-      "One or more evaluation years",
-      "not present in df.",
-      "Check value of argument eval_years."
-    )
+                          msg = paste(
+                            "One or more evaluation years",
+                            "not present in df.",
+                            "Check value of argument eval_years."
+                          )
   )
-
+  
   assertthat::assert_that(is.numeric(p_max) && p_max >= 0 && p_max <= 1,
-    msg = paste(
-      "p_max is a p-value: it has to be a",
-      "number between 0 and 1."
-    )
+                          msg = paste(
+                            "p_max is a p-value: it has to be a",
+                            "number between 0 and 1."
+                          )
   )
-
+  
   # Check type_indicator is one of the two allowed values
   assertthat::assert_that(type_indicator %in% c("observations", "occupancy"),
-    msg = paste(
-      "Invalid type_indicator.",
-      "type_indicator has to be one of:",
-      "observations, occupancy."
-    )
+                          msg = paste(
+                            "Invalid type_indicator.",
+                            "type_indicator has to be one of:",
+                            "observations, occupancy."
+                          )
   )
-
+  
   if (verbose == TRUE) {
     print(paste0("Analyzing: ", name, "(", taxon_key, ")"))
   }
-
+  
   if (nrow(df) > 0) {
     # Maximum minimum time series (year)
     fyear <- min(df[[year]], na.rm = TRUE) # first year
     lyear <- max(df[[year]], na.rm = TRUE) # last year
-
+    
     # Define model to use for GAM
     maxk <- max(round((lyear - fyear) / 10, digits = 0), 5) # max number of knots
   }
@@ -454,7 +454,7 @@ apply_gam <- function(df,
     )
     fm <- stats::formula(fm)
   }
-
+  
   # Initialization
   output_model <- dplyr::as_tibble(df)
   output_model <-
@@ -495,11 +495,11 @@ apply_gam <- function(df,
     dplyr::select(
       !!dplyr::sym(taxonKey),
       year,
-      em_status,
-      growth,
-      method
+      "em_status",
+      "growth",
+      "method"
     )
-
+  
   if (nrow(df) > 3 & sum(df[[y_var]][2:nrow(df)]) != 0) {
     result <- tryCatch(expr = {
       model <- mgcv::gam(
@@ -512,7 +512,7 @@ apply_gam <- function(df,
       summary_pv <- mgcv::summary.gam(model)$s.pv
       p_ok <- ifelse(any(summary_pv < p_max), TRUE, FALSE)
     }, error = function(e) e, warning = function(w) w)
-
+    
     if (class(result)[1] %in% c("simpleWarning", "simpleError")) {
       if (verbose) {
         warning(paste0(
@@ -552,13 +552,13 @@ apply_gam <- function(df,
           interval = "prediction",
           se.fit = TRUE
         )
-
+        
         # Calculate confidence intervals & backtransform to real scale
         intercept <- unname(model$coefficients[1])
         output_model$fit <- model$family$linkinv(temp$fit[, 1] + intercept)
         output_model$ucl <- model$family$linkinv(temp$fit[, 1] + intercept + temp$se.fit[, 1] * 1.96)
         output_model$lcl <- model$family$linkinv(temp$fit[, 1] + intercept - temp$se.fit[, 1] * 1.96)
-
+        
         # Check that fit ucl and lcl are all above zero
         output_model <-
           output_model %>%
@@ -567,47 +567,49 @@ apply_gam <- function(df,
             ucl = ifelse(.data$ucl < 0, 0, .data$ucl),
             lcl = ifelse(.data$lcl < 0, 0, .data$lcl)
           )
-
+        
         # Calculate first and second derivative + conf. interval
         deriv1 <- gratia::derivatives(model,
-          type = "central", order = 1, level = 0.8,
-          n = nrow(output_model), eps = 1e-4) %>%
-          # to remove by_var and fs_var 
-          # (probably in very new version of gratia, 0.8.x not compatible with R
-          # 4.2.1) errors with GitHub actions automatic checks 
-          dplyr::select(smooth, var, data, derivative, se, crit, lower, upper)
+                                      type = "central", order = 1, level = 0.8,
+                                      n = nrow(output_model), eps = 1e-4) %>%
+          dplyr::select(".smooth", ".derivative", ".se", ".crit", 
+                        ".lower_ci", ".upper_ci", !!dplyr::sym(year)) %>%
+          dplyr::rename_with(~sub("^\\.", "", .), 
+                             dplyr::all_of(c(".smooth", ".derivative", 
+                                             ".se", ".crit", 
+                                             ".lower_ci", ".upper_ci")))
         deriv2 <- gratia::derivatives(model,
-          type = "central", order = 2, level = 0.8,
-          n = nrow(output_model), eps = 1e-4) %>%
-          # to remove by_var and fs_var 
-          # (probably in very new version of gratia, 0.8.x not compatible with R
-          # 4.2.1)
-          dplyr::select(smooth, var, data, derivative, se, crit, lower, upper)
-
+                                      type = "central", order = 2, level = 0.8,
+                                      n = nrow(output_model), eps = 1e-4) %>%
+          dplyr::select(".smooth", ".derivative", ".se", ".crit", 
+                        ".lower_ci", ".upper_ci", !!dplyr::sym(year)) %>%
+          dplyr::rename_with(~sub("^\\.", "", .), 
+                             dplyr::all_of(c(".smooth", ".derivative", 
+                                             ".se", ".crit", 
+                                             ".lower_ci", ".upper_ci")))
+        
         # Emerging status based on first and second derivative
         em1 <-
           deriv1 %>%
-          dplyr::as_tibble() %>%
-          dplyr::filter(.data$var == year) %>%
+          dplyr::filter(!is.na(!!dplyr::sym(year))) %>%
           dplyr::mutate(em1 = dplyr::case_when(
-            .data$lower < 0 & .data$upper <= 0 ~ -1,
-            .data$lower < 0 & .data$upper > 0 ~ 0,
-            .data$lower >= 0 & .data$upper > 0 ~ 1
+            .data$lower_ci < 0 & .data$upper_ci <= 0 ~ -1,
+            .data$lower_ci < 0 & .data$upper_ci > 0 ~ 0,
+            .data$lower_ci >= 0 & .data$upper_ci > 0 ~ 1
           )) %>%
-          dplyr::select(!!dplyr::sym(year) := data, em1) %>%
+          dplyr::select(!!dplyr::sym(year), "em1") %>%
           dplyr::mutate(!!dplyr::sym(year) := round(!!dplyr::sym(year)))
-
+        
         em2 <- deriv2 %>%
-          dplyr::as_tibble() %>%
-          dplyr::filter(.data$var == year) %>%
+          dplyr::filter(!is.na(!!dplyr::sym(year))) %>%
           dplyr::mutate(em2 = dplyr::case_when(
-            .data$lower < 0 & .data$upper <= 0 ~ -1,
-            .data$lower < 0 & .data$upper > 0 ~ 0,
-            .data$lower >= 0 & .data$upper > 0 ~ 1
+            .data$lower_ci < 0 & .data$upper_ci <= 0 ~ -1,
+            .data$lower_ci < 0 & .data$upper_ci > 0 ~ 0,
+            .data$lower_ci >= 0 & .data$upper_ci > 0 ~ 1
           )) %>%
-          dplyr::select(!!dplyr::sym(year) := data, em2) %>%
+          dplyr::select(!!dplyr::sym(year), "em2") %>%
           dplyr::mutate(!!dplyr::sym(year) := round(!!dplyr::sym(year)))
-
+        
         em_level_gam <- dplyr::full_join(em1, em2, by = year) %>%
           dplyr::mutate(em = dplyr::case_when(
             .data$em1 == 1 & .data$em2 == 1 ~ 4,
@@ -620,7 +622,7 @@ apply_gam <- function(df,
             .data$em1 == -1 & .data$em2 == 0 ~ -3,
             .data$em1 == -1 & .data$em2 == -1 ~ -4
           ))
-
+        
         # Emerging status
         em_levels <-
           em_level_gam %>%
@@ -630,21 +632,23 @@ apply_gam <- function(df,
             .data$em < 3 ~ 2, # potentially emerging
             .data$em >= 3 ~ 3 # emerging
           ))
-
+        
         output_model <- dplyr::left_join(output_model, em_levels, by = year)
-
+        
         # Lower value of first derivative (minimal guaranteed growth) if positive
         lower_deriv1 <-
           deriv1 %>%
-          dplyr::filter(.data$var == year) %>%
-          dplyr::rename(!!dplyr::sym(year) := data) %>%
-          dplyr::mutate(!!dplyr::sym(year) := round(!!dplyr::sym(year), digits = 0)) %>%
-          dplyr::mutate(growth = model$family$linkinv(.data$lower)) %>%
-          dplyr::select(!!dplyr::sym(year), growth)
-
+          dplyr::filter(!is.na(!!dplyr::sym(year))) %>%
+          dplyr::mutate(!!dplyr::sym(year) := round(!!dplyr::sym(year), 
+                                                    digits = 0)) %>%
+          dplyr::mutate(growth = model$family$linkinv(.data$lower_ci)) %>%
+          dplyr::select(!!dplyr::sym(year), "growth")
+        
         # Add lower value of first derivative
-        output_model <- dplyr::left_join(output_model, lower_deriv1, by = "year")
-
+        output_model <- dplyr::left_join(output_model, 
+                                         lower_deriv1, 
+                                         by = "year")
+        
         # Get emerging status summary for output
         emerging_status_output <-
           output_model %>%
@@ -652,9 +656,9 @@ apply_gam <- function(df,
           dplyr::select(
             !!dplyr::sym(taxonKey),
             year,
-            em_status,
-            growth,
-            method
+            "em_status",
+            "growth",
+            "method"
           )
         # Create plot with conf. interval + colour for status
         plot_gam <- plot_ribbon_em(
@@ -715,7 +719,7 @@ apply_gam <- function(df,
     }
     ggplot2::ggsave(filename = file_name, plot_gam)
   }
-
+  
   return(list(
     em_summary = emerging_status_output,
     model = model,
@@ -765,7 +769,7 @@ plot_ribbon_em <- function(df_plot,
     ggplot2::geom_point(color = "black") +
     ggplot2::ylab(y_label) +
     ggplot2::ggtitle(ptitle)
-
+  
   if (all(
     all(abs(df_plot$lcl < 10^10)),
     all(abs(df_plot$ucl < 10^10)),
@@ -773,8 +777,8 @@ plot_ribbon_em <- function(df_plot,
   )) {
     g <- g +
       ggplot2::geom_ribbon(ggplot2::aes(ymax = .data$ucl, ymin = .data$lcl),
-        fill = grDevices::grey(0.5),
-        alpha = 0.4
+                           fill = grDevices::grey(0.5),
+                           alpha = 0.4
       ) +
       ggplot2::geom_line(ggplot2::aes(x = .data$year, y = .data$fit),
                          color = "grey50") +
@@ -830,6 +834,6 @@ add_annotation <- function(
                       vjust = 1,
                       label = text,
                       colour = colour
-  )
+    )
   return(annotated_plot)
 }

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -49,8 +49,8 @@
 #'   \item `em_summary`: df. A data.frame summarizing the emerging status
 #'   outputs. `em_summary` contains as many rows as the length of input variable
 #'   `eval_year`. So, if you evaluate GAM on three years, `em_summary` will
-#'   contain three rows. Columns:
-#'   - `taxonKey`: column containing taxon ID. Column name equal to value of
+#'   contain three rows. It contains the following columns:
+#'   - `"taxonKey"`: column containing taxon ID. Column name equal to value of
 #'   argument `taxonKey`.
 #'   - `"year"`: column containing temporal values. Column name equal
 #'   to value of argument `year`. Column itself is equal to value of
@@ -68,7 +68,7 @@
 #'   `NULL` if GAM cannot be applied.
 #'   
 #'   \item `output`: df. Complete data.frame containing more details than the
-#'   summary `em_summary`. Columns:
+#'   summary `em_summary`. It contains the following columns:
 #'   - `taxonKey`: column containing taxon ID. Column name equal to value of
 #'   argument `taxonKey`.
 #'   - `canonicalName`: name related to 
@@ -90,7 +90,7 @@
 #'   derivative, if positive. It represents the lower guaranteed growth.
 #'   
 #'   \item `first_derivative`: df. Data.frame with details of first derivatives.
-#'   It contains following columns:
+#'   It contains the following columns:
 #'   - `smooth`: smoooth identifier. Example: `s(year)`.
 #'   - `var`: character. Column name the smoother is applied to.
 #'   - `data`: numeric. Data in columns defined by `var`.
@@ -102,10 +102,11 @@
 #'   derivative of the estimated smooth at the specific confidence level. In our
 #'   case the confidence level is hard-coded: 0.8.
 #'   Then `crit <- qnorm(p = (1-0.8)/2, mean = 0, sd = 1, lower.tail = FALSE)`.
-#'   - `lower`: numeric. Lower bound of the confidence interval of the
+#'   - `lower_ci`: numeric. Lower bound of the confidence interval of the
 #'   estimated smooth.
-#'   - `upper`: numeric. Upper bound of the
+#'   - `upper_ci`: numeric. Upper bound of the
 #'   confidence interval of the estimated smooth.
+#'   - value of argument `year`: column with temporal values.
 #'   
 #'   \item `second_derivative`: df. Data.frame with details of second
 #'   derivatives. Same columns as `first_derivatives`.

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -12,37 +12,34 @@
 #'   be passed as string, e.g. `"time"`. Default: `"year"`.
 #' @param taxonKey character. Name of column containing taxon IDs. It has to be
 #'   passed as string, e.g. `"taxon"`. Default: `"taxonKey"`.
-#' @param type_indicator character. One of `"observations"`,
-#'   `"occupancy"`. Used in title of the output plot. Default:
-#'   `"observations"`.
-#' @param baseline_var character. Name of the column containing values to use
-#'   as additional covariate. Such covariate is introduced in the model to
-#'   correct research effort bias. Default: `NULL`. If `NULL` internal
-#'   variable `method_em = "basic"`, otherwise `method_em = "correct_baseline"`.
-#'   Value of `method_em` will be part of title of output plot.
+#' @param type_indicator character. One of `"observations"`, `"occupancy"`. Used
+#'   in title of the output plot. Default: `"observations"`.
+#' @param baseline_var character. Name of the column containing values to use as
+#'   additional covariate. Such covariate is introduced in the model to correct
+#'   research effort bias. Default: `NULL`. If `NULL` internal variable
+#'   `method_em = "basic"`, otherwise `method_em = "correct_baseline"`. Value of
+#'   `method_em` will be part of title of output plot.
 #' @param  p_max numeric. A value between 0 and 1. Default: 0.1.
 #' @param taxon_key numeric, character. Taxon key the timeseries belongs to.
 #'   Used exclusively in graph title and filename (if `saveplot = TRUE`).
 #'   Default: `NULL`.
 #' @param name character. Species name the timeseries belongs to. Used
-#'   exclusively in graph title and filename (if `saveplot = TRUE`).
-#'   Default: `NULL`.
+#'   exclusively in graph title and filename (if `saveplot = TRUE`). Default:
+#'   `NULL`.
 #' @param df_title character. Any string you would like to add to graph titles
 #'   and filenames (if `saveplot = TRUE`). The title is always composed of:
-#'   `"GAM"` + `type_indicator` + `method_em` + `taxon_key`
-#'   + `name` + `df_title` separated by underscore ("_"). Default:
-#'   `NULL`.
-#' @param x_label character. x-axis label of output plot. Default:
-#'   `"year"`.
-#' @param y_label character. y-axis label of output plot. Default:
-#'   `"number of observations"`.
+#'   `"GAM"` + `type_indicator` + `method_em` + `taxon_key` + `name` +
+#'   `df_title` separated by underscore ("_"). Default: `NULL`.
+#' @param x_label character. x-axis label of output plot. Default: `"year"`.
+#' @param y_label character. y-axis label of output plot. Default: `"number of
+#'   observations"`.
 #' @param saveplot logical. If `TRUE` the plots are authomatically saved.
 #'   Default: `FALSE`.
 #' @param dir_name character. Path of directory where saving plots. If path
 #'   doesn't exists, directory will be created. Example: "./output/graphs/". If
 #'   `NULL`, plots are saved in current directory. Default: `NULL`.
-#' @param verbose logical. If `TRUE` status of processing and possible
-#'   issues are returned. Default: `FALSE`.
+#' @param verbose logical. If `TRUE` status of processing and possible issues
+#'   are returned. Default: `FALSE`.
 #'
 #' @return list with six slots:
 #' \enumerate{
@@ -63,18 +60,13 @@
 #'   derivative, if positive. It represents the lower guaranteed growth.
 #'   - `method`: character. GAM method, One of: `"correct_baseline"` and
 #'   `"basic"`. See details above in description of argument `use_baseline`.
-#'   
+#'
 #'   \item `model`: gam object. The model as returned by `gam()` function.
 #'   `NULL` if GAM cannot be applied.
-#'   
+#'
 #'   \item `output`: df. Complete data.frame containing more details than the
 #'   summary `em_summary`. It contains the following columns:
-#'   - `taxonKey`: column containing taxon ID. Column name equal to value of
-#'   argument `taxonKey`.
-#'   - `canonicalName`: name related to 
-#'   - `year`
-#'   - `n`
-#'   - `n_class`
+#'   - all columns in `df`.
 #'   - `method`: character. GAM method, One of: `"correct_baseline"` and
 #'   `"basic"`. See details above in description of argument `use_baseline`.
 #'   - `fit`: numeric. Fit values.
@@ -82,18 +74,16 @@
 #'   - `lcl`: numeric. The lower confidence level values.
 #'   - `em1`: numeric. The emergency value for the 1st derivative. -1, 0 or +1.
 #'   - `em2`: numeric. The emergency value for the 2nd derivative: -1, 0 or +1.
-#'   - `em`: numeric. The emergency value: from -4 to +4, based on `em1` and 
-#'   `em2`. See Details. 
+#'   - `em`: numeric. The emergency value: from -4 to +4, based on `em1` and
+#'   `em2`. See Details.
 #'   - `em_status`: numeric. Emerging statuses, an integer
 #'   between 0 and 3. See Details.
 #'   - `growth`: numeric. Lower limit of GAM confidence interval for the first
 #'   derivative, if positive. It represents the lower guaranteed growth.
-#'   
+#'
 #'   \item `first_derivative`: df. Data.frame with details of first derivatives.
 #'   It contains the following columns:
 #'   - `smooth`: smoooth identifier. Example: `s(year)`.
-#'   - `var`: character. Column name the smoother is applied to.
-#'   - `data`: numeric. Data in columns defined by `var`.
 #'   - `derivative`: numeric. Value of first derivative.
 #'   - `se`: numeric. Standard error of `derivative`.
 #'   - `crit`: numeric. Critical value required such that
@@ -107,10 +97,12 @@
 #'   - `upper_ci`: numeric. Upper bound of the
 #'   confidence interval of the estimated smooth.
 #'   - value of argument `year`: column with temporal values.
-#'   
+#'   - value of argument `baseline_var`: column with the fitted values for the 
+#'   baseline. If `baseline_var` is `NULL`, this column is not present.
+#'
 #'   \item `second_derivative`: df. Data.frame with details of second
 #'   derivatives. Same columns as `first_derivatives`.
-#'   
+#'
 #'   \item `plot`: a ggplot2 object. Plot of observations with GAM output and
 #' emerging status. If emerging status cannot be assessed only observations are
 #' plotted.
@@ -118,71 +110,69 @@
 #' @export
 #' @importFrom dplyr %>% .data
 #' @importFrom rlang !! :=
-#' 
-#' @details
-#' The GAM modelling is performed using the `mgcvb::gam()`. To use this function, we pass:
+#'
+#' @details The GAM modelling is performed using the `mgcvb::gam()`. To use this
+#'   function, we pass:
 #' - a formula
 #' - a family object specifying the distribution
 #' - a smoothing parameter estimation method
-#' 
-#' For more information about all other arguments, see `[mgcv::gam()]`.
-#' 
-#' If no covariate is used (`baseline_var` = NULL), the GAM formula is: 
-#' `n ~ s(year, k = maxk, m = 3, bs = "tp")`. Otherwise the GAM formula has a
-#' second term, `s(n_covariate)` and so the GAM formula is 
-#' `n ~ s(year, k = maxk, m = 3, bs = "tp") + s(n_covariate)`.
-#' 
-#' Description of the parameters present in the formula above:
+#'
+#'   For more information about all other arguments, see `[mgcv::gam()]`.
+#'
+#'   If no covariate is used (`baseline_var` = NULL), the GAM formula is: `n ~
+#'   s(year, k = maxk, m = 3, bs = "tp")`. Otherwise the GAM formula has a
+#'   second term, `s(n_covariate)` and so the GAM formula is `n ~ s(year, k =
+#'   maxk, m = 3, bs = "tp") + s(n_covariate)`.
+#'
+#'   Description of the parameters present in the formula above:
 #' - `k`: dimension of the basis used to represent the smooth term, i.e. the
-#' number of _knots_ used for calculating the smoother. We #' set `k` to `maxk`,
-#' which is the number of decades in the time series. If less than 5 decades are
-#' present in the data, `maxk` is #' set to 5.
+#'   number of _knots_ used for calculating the smoother. We #' set `k` to
+#'   `maxk`, which is the number of decades in the time series. If less than 5
+#'   decades are present in the data, `maxk` is #' set to 5.
 #' - `bs` indicates the basis to use for the smoothing: we uses the default
-#' penalized thin plate regression splines.
+#'   penalized thin plate regression splines.
 #' - `m` specifies the order of the derivatives in the thin plate spline
-#' penalty. We use `m = 3`, the default value.
-#' 
-#' We use `[mgcv::nb()]`, a negative binomial family to perform the GAM.
-#' 
-#' The smoothing parameter estimation method is set to REML (Restricted maximum
-#' likelihood approach). If the P-value of the GAM smoother(s) is/are above
-#' threshold value `p_max`, GAM is not performed and the next warning is
-#' returned: "GAM output cannot be used: p-values of all GAM smoothers are above
-#' \{p_max\}" where `p_max` is the P-value used as threshold as defined by
-#' argument `p_max`.
-#' 
-#' If the `mgcv::gam()` returns an error or a warning, the following message is
-#' returned to the user: "GAM (\{method_em\}) cannot be performed or cannot
-#' converge.", where `method_em` is one of `"basic"` or `"correct_baseline"`.
-#' See argument `baseline_var`.
-#' 
-#' The first and second derivatives of the smoother is calculated using function
-#' `gratia::derivatives()` with the following hard coded arguments:
-#' 
+#'   penalty. We use `m = 3`, the default value.
+#'
+#'   We use `[mgcv::nb()]`, a negative binomial family to perform the GAM.
+#'
+#'   The smoothing parameter estimation method is set to REML (Restricted
+#'   maximum likelihood approach). If the P-value of the GAM smoother(s) is/are
+#'   above threshold value `p_max`, GAM is not performed and the next warning is
+#'   returned: "GAM output cannot be used: p-values of all GAM smoothers are
+#'   above \{p_max\}" where `p_max` is the P-value used as threshold as defined
+#'   by argument `p_max`.
+#'
+#'   If the `mgcv::gam()` returns an error or a warning, the following message
+#'   is returned to the user: "GAM (\{method_em\}) cannot be performed or cannot
+#'   converge.", where `method_em` is one of `"basic"` or `"correct_baseline"`.
+#'   See argument `baseline_var`.
+#'
+#'   The first and second derivatives of the smoother is calculated using
+#'   function `gratia::derivatives()` with the following hard coded arguments:
+#'
 #' - `type`: the type of finite difference used. Set  to `"central"`.
 #' - `order`: 1 for the first derivative, 2 for the second derivative
 #' - `level`: the confidence level. Set to 0.8
 #' - `eps`: the finite difference. Set to 1e-4.
-#' 
-#' For more details, please check \link[gratia]{derivatives}.
-#' 
-#' The sign of the lower and upper confidence levels of the first and second
-#' derivatives are used to define a detailed emergency status (`em`) which is
-#' internally used to return the emergency status, `em_status`, which is a
-#' column of the returned data.frame `em_summary`.
-#' 
-#' | ucl-1 | lcl-1 | ucl-2 | lcl-2 | em | em_status |
-#' | --- | --- | --- | --- | --- | --- |
-#' | + | + | + | + | 4 | 3 (emerging) |
-#' | + | + | + | - | 3 | 3 (emerging) |
-#' | + | + | - | - | 2 | 2 (potentially emerging) |
-#' | - | + | + | + | 1 | 2 (potentially emerging) |
-#' | + | - | + | - | 0 | 1 (unclear) |
-#' | + | - | - | - | -1 | 0 (not emerging) |
-#' | - | - | + | + | -2 | 0 (not emerging) |
-#' | - | - | + | - | -3 | 0 (not emerging) |
-#' | - | - | - | - | -4 | 0 (not emerging) |
-#' 
+#'
+#'   For more details, please check \link[gratia]{derivatives}.
+#'
+#'   The sign of the lower and upper confidence levels of the first and second
+#'   derivatives are used to define a detailed emergency status (`em`) which is
+#'   internally used to return the emergency status, `em_status`, which is a
+#'   column of the returned data.frame `em_summary`.
+#'
+#'   | ucl-1 | lcl-1 | ucl-2 | lcl-2 | em | em_status | | --- | --- | --- | ---
+#'   |
+#' --- | --- | | + | + | + | + | 4 | 3 (emerging) | | + | + | + | - | 3 | 3
+#'   (emerging) | | + | + | - | - | 2 | 2 (potentially emerging) | | - | + | + |
+#'   + | 1 | 2 (potentially emerging) | | + | - | + | - | 0 | 1 (unclear) | | +
+#'   | - | - | - | -1 | 0 (not emerging) | | - | - | + | + | -2 | 0 (not
+#'   emerging) | |
+#' - | - | + | - | -3 | 0 (not emerging) | | - | - | - | - | -4 | 0 (not
+#'   emerging) |
+#'
 #' @examples
 #' \dontrun{
 #' library(dplyr)
@@ -275,7 +265,7 @@
 #' )
 #' no_gam_applied$plot
 #' }
-#'
+#' 
 apply_gam <- function(df,
                       y_var,
                       eval_years,

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -519,7 +519,7 @@ apply_gam <- function(df,
     dplyr::filter(!!dplyr::sym(year) %in% eval_years) %>%
     dplyr::select(
       !!dplyr::sym(taxonKey),
-      year,
+      !!dplyr::sym(year),
       "em_status",
       "growth",
       "method"
@@ -596,18 +596,22 @@ apply_gam <- function(df,
         # Calculate first and second derivative + conf. interval
         deriv1 <- gratia::derivatives(model,
                                       type = "central", order = 1, level = 0.8,
-                                      n = nrow(output_model), eps = 1e-4) %>%
-          dplyr::select(".smooth", ".derivative", ".se", ".crit", 
-                        ".lower_ci", ".upper_ci", !!dplyr::sym(year)) %>%
+                                      n = nrow(output_model), eps = 1e-4)
+        cols_to_select <- c(".smooth", ".derivative", ".se", ".crit",
+                            ".lower_ci", ".upper_ci",
+                            year, baseline_var)
+        deriv1 <- deriv1 %>%
+          dplyr::select(dplyr::all_of(cols_to_select)) %>%
           dplyr::rename_with(~sub("^\\.", "", .), 
                              dplyr::all_of(c(".smooth", ".derivative", 
                                              ".se", ".crit", 
                                              ".lower_ci", ".upper_ci")))
         deriv2 <- gratia::derivatives(model,
                                       type = "central", order = 2, level = 0.8,
-                                      n = nrow(output_model), eps = 1e-4) %>%
-          dplyr::select(".smooth", ".derivative", ".se", ".crit", 
-                        ".lower_ci", ".upper_ci", !!dplyr::sym(year)) %>%
+                                      n = nrow(output_model), eps = 1e-4)
+        deriv2 <- deriv2 %>%
+          # same columns to select as for 1st derivative
+          dplyr::select(dplyr::all_of(cols_to_select)) %>%
           dplyr::rename_with(~sub("^\\.", "", .), 
                              dplyr::all_of(c(".smooth", ".derivative", 
                                              ".se", ".crit", 

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -50,7 +50,7 @@
 #'   outputs. `em_summary` contains as many rows as the length of input variable
 #'   `eval_year`. So, if you evaluate GAM on three years, `em_summary` will
 #'   contain three rows. Columns:
-#'   - `"taxonKey"`: column containing taxon ID. Column name equal to value of
+#'   - `taxonKey`: column containing taxon ID. Column name equal to value of
 #'   argument `taxonKey`.
 #'   - `"year"`: column containing temporal values. Column name equal
 #'   to value of argument `year`. Column itself is equal to value of
@@ -60,13 +60,35 @@
 #'   - `em_status`: numeric. Emerging statuses, an integer
 #'   between 0 and 3.
 #'   - `growth`: numeric. Lower limit of GAM confidence interval for the first
-#'   derivative. It represents the lower guaranteed growth.
+#'   derivative, if positive. It represents the lower guaranteed growth.
 #'   - `method`: character. GAM method, One of: `"correct_baseline"` and
 #'   `"basic"`. See details above in description of argument `use_baseline`.
+#'   
 #'   \item `model`: gam object. The model as returned by `gam()` function.
 #'   `NULL` if GAM cannot be applied.
+#'   
 #'   \item `output`: df. Complete data.frame containing more details than the
-#'   summary `em_summary`.
+#'   summary `em_summary`. Columns:
+#'   - `taxonKey`: column containing taxon ID. Column name equal to value of
+#'   argument `taxonKey`.
+#'   - `canonicalName`: name related to 
+#'   - `year`
+#'   - `n`
+#'   - `n_class`
+#'   - `method`: character. GAM method, One of: `"correct_baseline"` and
+#'   `"basic"`. See details above in description of argument `use_baseline`.
+#'   - `fit`: numeric. Fit values.
+#'   - `ucl`: numeric. The upper confidence level values.
+#'   - `lcl`: numeric. The lower confidence level values.
+#'   - `em1`: numeric. The emergency value for the 1st derivative. -1, 0 or +1.
+#'   - `em2`: numeric. The emergency value for the 2nd derivative: -1, 0 or +1.
+#'   - `em`: numeric. The emergency value: from -4 to +4, based on `em1` and 
+#'   `em2`. See Details. 
+#'   - `em_status`: numeric. Emerging statuses, an integer
+#'   between 0 and 3. See Details.
+#'   - `growth`: numeric. Lower limit of GAM confidence interval for the first
+#'   derivative, if positive. It represents the lower guaranteed growth.
+#'   
 #'   \item `first_derivative`: df. Data.frame with details of first derivatives.
 #'   It contains following columns:
 #'   - `smooth`: smoooth identifier. Example: `s(year)`.
@@ -84,8 +106,10 @@
 #'   estimated smooth.
 #'   - `upper`: numeric. Upper bound of the
 #'   confidence interval of the estimated smooth.
+#'   
 #'   \item `second_derivative`: df. Data.frame with details of second
 #'   derivatives. Same columns as `first_derivatives`.
+#'   
 #'   \item `plot`: a ggplot2 object. Plot of observations with GAM output and
 #' emerging status. If emerging status cannot be assessed only observations are
 #' plotted.
@@ -635,7 +659,8 @@ apply_gam <- function(df,
         
         output_model <- dplyr::left_join(output_model, em_levels, by = year)
         
-        # Lower value of first derivative (minimal guaranteed growth) if positive
+        # Lower value of first derivative (minimal guaranteed growth) if
+        # positive
         lower_deriv1 <-
           deriv1 %>%
           dplyr::filter(!is.na(!!dplyr::sym(year))) %>%

--- a/R/apply_gam.R
+++ b/R/apply_gam.R
@@ -255,6 +255,9 @@
 #' ),
 #' cobs = rep(0, 24)
 #' )
+#' 
+#' # if GAM cannot be applied a warning is returned and the plot mention it
+#' \dontrun{
 #' no_gam_applied <- apply_gam(df_gam,
 #'                             y_var = "obs",
 #'                             eval_years = 2018,
@@ -265,7 +268,7 @@
 #' )
 #' no_gam_applied$plot
 #' }
-#' 
+#' }
 apply_gam <- function(df,
                       y_var,
                       eval_years,

--- a/man/apply_gam.Rd
+++ b/man/apply_gam.Rd
@@ -38,15 +38,14 @@ be passed as string, e.g. \code{"time"}. Default: \code{"year"}.}
 \item{taxonKey}{character. Name of column containing taxon IDs. It has to be
 passed as string, e.g. \code{"taxon"}. Default: \code{"taxonKey"}.}
 
-\item{type_indicator}{character. One of \code{"observations"},
-\code{"occupancy"}. Used in title of the output plot. Default:
-\code{"observations"}.}
+\item{type_indicator}{character. One of \code{"observations"}, \code{"occupancy"}. Used
+in title of the output plot. Default: \code{"observations"}.}
 
-\item{baseline_var}{character. Name of the column containing values to use
-as additional covariate. Such covariate is introduced in the model to
-correct research effort bias. Default: \code{NULL}. If \code{NULL} internal
-variable \code{method_em = "basic"}, otherwise \code{method_em = "correct_baseline"}.
-Value of \code{method_em} will be part of title of output plot.}
+\item{baseline_var}{character. Name of the column containing values to use as
+additional covariate. Such covariate is introduced in the model to correct
+research effort bias. Default: \code{NULL}. If \code{NULL} internal variable
+\code{method_em = "basic"}, otherwise \code{method_em = "correct_baseline"}. Value of
+\code{method_em} will be part of title of output plot.}
 
 \item{p_max}{numeric. A value between 0 and 1. Default: 0.1.}
 
@@ -55,22 +54,17 @@ Used exclusively in graph title and filename (if \code{saveplot = TRUE}).
 Default: \code{NULL}.}
 
 \item{name}{character. Species name the timeseries belongs to. Used
-exclusively in graph title and filename (if \code{saveplot = TRUE}).
-Default: \code{NULL}.}
+exclusively in graph title and filename (if \code{saveplot = TRUE}). Default:
+\code{NULL}.}
 
 \item{df_title}{character. Any string you would like to add to graph titles
 and filenames (if \code{saveplot = TRUE}). The title is always composed of:
-\code{"GAM"} + \code{type_indicator} + \code{method_em} + \code{taxon_key}
-\itemize{
-\item \code{name} + \code{df_title} separated by underscore ("_"). Default:
-\code{NULL}.
-}}
+\code{"GAM"} + \code{type_indicator} + \code{method_em} + \code{taxon_key} + \code{name} +
+\code{df_title} separated by underscore ("_"). Default: \code{NULL}.}
 
-\item{x_label}{character. x-axis label of output plot. Default:
-\code{"year"}.}
+\item{x_label}{character. x-axis label of output plot. Default: \code{"year"}.}
 
-\item{y_label}{character. y-axis label of output plot. Default:
-\code{"number of observations"}.}
+\item{y_label}{character. y-axis label of output plot. Default: \code{"number of observations"}.}
 
 \item{saveplot}{logical. If \code{TRUE} the plots are authomatically saved.
 Default: \code{FALSE}.}
@@ -79,8 +73,8 @@ Default: \code{FALSE}.}
 doesn't exists, directory will be created. Example: "./output/graphs/". If
 \code{NULL}, plots are saved in current directory. Default: \code{NULL}.}
 
-\item{verbose}{logical. If \code{TRUE} status of processing and possible
-issues are returned. Default: \code{FALSE}.}
+\item{verbose}{logical. If \code{TRUE} status of processing and possible issues
+are returned. Default: \code{FALSE}.}
 }
 \value{
 list with six slots:
@@ -111,12 +105,7 @@ derivative, if positive. It represents the lower guaranteed growth.
 \item \code{output}: df. Complete data.frame containing more details than the
 summary \code{em_summary}. It contains the following columns:
 \itemize{
-\item \code{taxonKey}: column containing taxon ID. Column name equal to value of
-argument \code{taxonKey}.
-\item \code{canonicalName}: name related to
-\item \code{year}
-\item \code{n}
-\item \code{n_class}
+\item all columns in \code{df}.
 \item \code{method}: character. GAM method, One of: \code{"correct_baseline"} and
 \code{"basic"}. See details above in description of argument \code{use_baseline}.
 \item \code{fit}: numeric. Fit values.
@@ -136,8 +125,6 @@ derivative, if positive. It represents the lower guaranteed growth.
 It contains the following columns:
 \itemize{
 \item \code{smooth}: smoooth identifier. Example: \code{s(year)}.
-\item \code{var}: character. Column name the smoother is applied to.
-\item \code{data}: numeric. Data in columns defined by \code{var}.
 \item \code{derivative}: numeric. Value of first derivative.
 \item \code{se}: numeric. Standard error of \code{derivative}.
 \item \code{crit}: numeric. Critical value required such that
@@ -151,6 +138,8 @@ estimated smooth.
 \item \code{upper_ci}: numeric. Upper bound of the
 confidence interval of the estimated smooth.
 \item value of argument \code{year}: column with temporal values.
+\item value of argument \code{baseline_var}: column with the fitted values for the
+baseline. If \code{baseline_var} is \code{NULL}, this column is not present.
 }
 
 \item \code{second_derivative}: df. Data.frame with details of second
@@ -166,71 +155,67 @@ This function applies generalized additive models (GAM) to assess emerging
 status for a certain time window.
 }
 \details{
-The GAM modelling is performed using the \code{mgcvb::gam()}. To use this function, we pass:
+The GAM modelling is performed using the \code{mgcvb::gam()}. To use this
+function, we pass:
 \itemize{
 \item a formula
 \item a family object specifying the distribution
 \item a smoothing parameter estimation method
-}
 
 For more information about all other arguments, see \verb{[mgcv::gam()]}.
 
-If no covariate is used (\code{baseline_var} = NULL), the GAM formula is:
-\code{n ~ s(year, k = maxk, m = 3, bs = "tp")}. Otherwise the GAM formula has a
-second term, \code{s(n_covariate)} and so the GAM formula is
-\code{n ~ s(year, k = maxk, m = 3, bs = "tp") + s(n_covariate)}.
+If no covariate is used (\code{baseline_var} = NULL), the GAM formula is: \code{n ~ s(year, k = maxk, m = 3, bs = "tp")}. Otherwise the GAM formula has a
+second term, \code{s(n_covariate)} and so the GAM formula is \code{n ~ s(year, k = maxk, m = 3, bs = "tp") + s(n_covariate)}.
 
 Description of the parameters present in the formula above:
-\itemize{
 \item \code{k}: dimension of the basis used to represent the smooth term, i.e. the
-number of \emph{knots} used for calculating the smoother. We #' set \code{k} to \code{maxk},
-which is the number of decades in the time series. If less than 5 decades are
-present in the data, \code{maxk} is #' set to 5.
+number of \emph{knots} used for calculating the smoother. We #' set \code{k} to
+\code{maxk}, which is the number of decades in the time series. If less than 5
+decades are present in the data, \code{maxk} is #' set to 5.
 \item \code{bs} indicates the basis to use for the smoothing: we uses the default
 penalized thin plate regression splines.
 \item \code{m} specifies the order of the derivatives in the thin plate spline
 penalty. We use \code{m = 3}, the default value.
-}
 
 We use \verb{[mgcv::nb()]}, a negative binomial family to perform the GAM.
 
-The smoothing parameter estimation method is set to REML (Restricted maximum
-likelihood approach). If the P-value of the GAM smoother(s) is/are above
-threshold value \code{p_max}, GAM is not performed and the next warning is
-returned: "GAM output cannot be used: p-values of all GAM smoothers are above
-\{p_max\}" where \code{p_max} is the P-value used as threshold as defined by
-argument \code{p_max}.
+The smoothing parameter estimation method is set to REML (Restricted
+maximum likelihood approach). If the P-value of the GAM smoother(s) is/are
+above threshold value \code{p_max}, GAM is not performed and the next warning is
+returned: "GAM output cannot be used: p-values of all GAM smoothers are
+above \{p_max\}" where \code{p_max} is the P-value used as threshold as defined
+by argument \code{p_max}.
 
-If the \code{mgcv::gam()} returns an error or a warning, the following message is
-returned to the user: "GAM (\{method_em\}) cannot be performed or cannot
+If the \code{mgcv::gam()} returns an error or a warning, the following message
+is returned to the user: "GAM (\{method_em\}) cannot be performed or cannot
 converge.", where \code{method_em} is one of \code{"basic"} or \code{"correct_baseline"}.
 See argument \code{baseline_var}.
 
-The first and second derivatives of the smoother is calculated using function
-\code{gratia::derivatives()} with the following hard coded arguments:
-\itemize{
+The first and second derivatives of the smoother is calculated using
+function \code{gratia::derivatives()} with the following hard coded arguments:
 \item \code{type}: the type of finite difference used. Set  to \code{"central"}.
 \item \code{order}: 1 for the first derivative, 2 for the second derivative
 \item \code{level}: the confidence level. Set to 0.8
 \item \code{eps}: the finite difference. Set to 1e-4.
-}
 
 For more details, please check \link[gratia]{derivatives}.
 
 The sign of the lower and upper confidence levels of the first and second
 derivatives are used to define a detailed emergency status (\code{em}) which is
 internally used to return the emergency status, \code{em_status}, which is a
-column of the returned data.frame \code{em_summary}.\tabular{llllll}{
-   ucl-1 \tab lcl-1 \tab ucl-2 \tab lcl-2 \tab em \tab em_status \cr
-   + \tab + \tab + \tab + \tab 4 \tab 3 (emerging) \cr
-   + \tab + \tab + \tab - \tab 3 \tab 3 (emerging) \cr
-   + \tab + \tab - \tab - \tab 2 \tab 2 (potentially emerging) \cr
-   - \tab + \tab + \tab + \tab 1 \tab 2 (potentially emerging) \cr
-   + \tab - \tab + \tab - \tab 0 \tab 1 (unclear) \cr
-   + \tab - \tab - \tab - \tab -1 \tab 0 (not emerging) \cr
-   - \tab - \tab + \tab + \tab -2 \tab 0 (not emerging) \cr
-   - \tab - \tab + \tab - \tab -3 \tab 0 (not emerging) \cr
-   - \tab - \tab - \tab - \tab -4 \tab 0 (not emerging) \cr
+column of the returned data.frame \code{em_summary}.
+
+| ucl-1 | lcl-1 | ucl-2 | lcl-2 | em | em_status | | --- | --- | --- | ---
+|
+--- | --- | | + | + | + | + | 4 | 3 (emerging) | | + | + | + | - | 3 | 3
+(emerging) | | + | + | - | - | 2 | 2 (potentially emerging) | | - | + | + |
+\itemize{
+\item | 1 | 2 (potentially emerging) | | + | - | + | - | 0 | 1 (unclear) | | +
+| - | - | - | -1 | 0 (not emerging) | | - | - | + | + | -2 | 0 (not
+emerging) | |
+}
+\item | - | + | - | -3 | 0 (not emerging) | | - | - | - | - | -4 | 0 (not
+emerging) |
 }
 }
 \examples{

--- a/man/apply_gam.Rd
+++ b/man/apply_gam.Rd
@@ -88,9 +88,9 @@ list with six slots:
 \item \code{em_summary}: df. A data.frame summarizing the emerging status
 outputs. \code{em_summary} contains as many rows as the length of input variable
 \code{eval_year}. So, if you evaluate GAM on three years, \code{em_summary} will
-contain three rows. Columns:
+contain three rows. It contains the following columns:
 \itemize{
-\item \code{taxonKey}: column containing taxon ID. Column name equal to value of
+\item \code{"taxonKey"}: column containing taxon ID. Column name equal to value of
 argument \code{taxonKey}.
 \item \code{"year"}: column containing temporal values. Column name equal
 to value of argument \code{year}. Column itself is equal to value of
@@ -109,7 +109,7 @@ derivative, if positive. It represents the lower guaranteed growth.
 \code{NULL} if GAM cannot be applied.
 
 \item \code{output}: df. Complete data.frame containing more details than the
-summary \code{em_summary}. Columns:
+summary \code{em_summary}. It contains the following columns:
 \itemize{
 \item \code{taxonKey}: column containing taxon ID. Column name equal to value of
 argument \code{taxonKey}.
@@ -133,7 +133,7 @@ derivative, if positive. It represents the lower guaranteed growth.
 }
 
 \item \code{first_derivative}: df. Data.frame with details of first derivatives.
-It contains following columns:
+It contains the following columns:
 \itemize{
 \item \code{smooth}: smoooth identifier. Example: \code{s(year)}.
 \item \code{var}: character. Column name the smoother is applied to.
@@ -146,10 +146,11 @@ the upper and lower bounds of the confidence interval on the first
 derivative of the estimated smooth at the specific confidence level. In our
 case the confidence level is hard-coded: 0.8.
 Then \code{crit <- qnorm(p = (1-0.8)/2, mean = 0, sd = 1, lower.tail = FALSE)}.
-\item \code{lower}: numeric. Lower bound of the confidence interval of the
+\item \code{lower_ci}: numeric. Lower bound of the confidence interval of the
 estimated smooth.
-\item \code{upper}: numeric. Upper bound of the
+\item \code{upper_ci}: numeric. Upper bound of the
 confidence interval of the estimated smooth.
+\item value of argument \code{year}: column with temporal values.
 }
 
 \item \code{second_derivative}: df. Data.frame with details of second

--- a/man/apply_gam.Rd
+++ b/man/apply_gam.Rd
@@ -90,7 +90,7 @@ outputs. \code{em_summary} contains as many rows as the length of input variable
 \code{eval_year}. So, if you evaluate GAM on three years, \code{em_summary} will
 contain three rows. Columns:
 \itemize{
-\item \code{"taxonKey"}: column containing taxon ID. Column name equal to value of
+\item \code{taxonKey}: column containing taxon ID. Column name equal to value of
 argument \code{taxonKey}.
 \item \code{"year"}: column containing temporal values. Column name equal
 to value of argument \code{year}. Column itself is equal to value of
@@ -100,15 +100,41 @@ column.
 \item \code{em_status}: numeric. Emerging statuses, an integer
 between 0 and 3.
 \item \code{growth}: numeric. Lower limit of GAM confidence interval for the first
-derivative. It represents the lower guaranteed growth.
+derivative, if positive. It represents the lower guaranteed growth.
 \item \code{method}: character. GAM method, One of: \code{"correct_baseline"} and
 \code{"basic"}. See details above in description of argument \code{use_baseline}.
+}
+
 \item \code{model}: gam object. The model as returned by \code{gam()} function.
 \code{NULL} if GAM cannot be applied.
+
 \item \code{output}: df. Complete data.frame containing more details than the
-summary \code{em_summary}.
+summary \code{em_summary}. Columns:
+\itemize{
+\item \code{taxonKey}: column containing taxon ID. Column name equal to value of
+argument \code{taxonKey}.
+\item \code{canonicalName}: name related to
+\item \code{year}
+\item \code{n}
+\item \code{n_class}
+\item \code{method}: character. GAM method, One of: \code{"correct_baseline"} and
+\code{"basic"}. See details above in description of argument \code{use_baseline}.
+\item \code{fit}: numeric. Fit values.
+\item \code{ucl}: numeric. The upper confidence level values.
+\item \code{lcl}: numeric. The lower confidence level values.
+\item \code{em1}: numeric. The emergency value for the 1st derivative. -1, 0 or +1.
+\item \code{em2}: numeric. The emergency value for the 2nd derivative: -1, 0 or +1.
+\item \code{em}: numeric. The emergency value: from -4 to +4, based on \code{em1} and
+\code{em2}. See Details.
+\item \code{em_status}: numeric. Emerging statuses, an integer
+between 0 and 3. See Details.
+\item \code{growth}: numeric. Lower limit of GAM confidence interval for the first
+derivative, if positive. It represents the lower guaranteed growth.
+}
+
 \item \code{first_derivative}: df. Data.frame with details of first derivatives.
 It contains following columns:
+\itemize{
 \item \code{smooth}: smoooth identifier. Example: \code{s(year)}.
 \item \code{var}: character. Column name the smoother is applied to.
 \item \code{data}: numeric. Data in columns defined by \code{var}.
@@ -124,12 +150,14 @@ Then \code{crit <- qnorm(p = (1-0.8)/2, mean = 0, sd = 1, lower.tail = FALSE)}.
 estimated smooth.
 \item \code{upper}: numeric. Upper bound of the
 confidence interval of the estimated smooth.
+}
+
 \item \code{second_derivative}: df. Data.frame with details of second
 derivatives. Same columns as \code{first_derivatives}.
+
 \item \code{plot}: a ggplot2 object. Plot of observations with GAM output and
 emerging status. If emerging status cannot be assessed only observations are
 plotted.
-}
 }
 }
 \description{

--- a/man/apply_gam.Rd
+++ b/man/apply_gam.Rd
@@ -300,6 +300,9 @@ obs = c(
 ),
 cobs = rep(0, 24)
 )
+
+# if GAM cannot be applied a warning is returned and the plot mention it
+\dontrun{
 no_gam_applied <- apply_gam(df_gam,
                             y_var = "obs",
                             eval_years = 2018,
@@ -310,5 +313,5 @@ no_gam_applied <- apply_gam(df_gam,
 )
 no_gam_applied$plot
 }
-
+}
 }

--- a/tests/testthat/test-output_apply_gam.R
+++ b/tests/testthat/test-output_apply_gam.R
@@ -526,26 +526,42 @@ testthat::test_that("Test first derivative", {
   expect_null(corrected_gam_bad_ys$first_derivative)
 
   # first derivatives has right columns
+  expected_cols_basic <- c(
+    "smooth",
+    "derivative",
+    "se",
+    "crit",
+    "lower_ci",
+    "upper_ci",
+    "year"
+  )
   testthat::expect_that(
     basic_gam$first_derivative,
-    has_names(expected = c(
-      "smooth",
-      "var",
-      "data",
-      "derivative",
-      "se",
-      "crit",
-      "lower",
-      "upper"
-    ))
+    has_names(expected = expected_cols_basic)
   )
-  testthat::expect_true(all(names(basic_gam$first_derivative) ==
-    names(basic_gam_ys$first_derivative)))
-  testthat::expect_true(all(names(basic_gam$first_derivative) ==
-    names(corrected_gam$first_derivative)))
-  testthat::expect_true(all(names(corrected_gam$first_derivative) ==
-    names(corrected_gam_ys$first_derivative)))
-
+  testthat::expect_that(
+    basic_gam_ys$first_derivative,
+    has_names(expected = expected_cols_basic)
+  )
+  expected_cols_corrected <- c(
+    "smooth",
+    "derivative",
+    "se",
+    "crit",
+    "lower_ci",
+    "upper_ci",
+    "year",
+    "baseline_observations"
+  )
+  testthat::expect_that(
+    corrected_gam$first_derivative,
+    has_names(expected = expected_cols_corrected)
+  )
+  testthat::expect_that(
+    corrected_gam_ys$first_derivative,
+    has_names(expected = expected_cols_corrected)
+  )
+  
   # smooth column contains only s(year) for basic gam
   testthat::expect_true(unique(basic_gam$first_derivative$smooth) == "s(year)")
   testthat::expect_true(unique(basic_gam_ys$first_derivative$smooth) == "s(year)")
@@ -559,55 +575,47 @@ testthat::test_that("Test first derivative", {
   testthat::expect_true(all(corrected_gam_ys$first_derivative$smooth %in%
     c("s(year)", "s(baseline_observations)")))
 
-  # var contains always value "year" if GAM is performed
-  testthat::expect_true("year" %in% basic_gam$first_derivative$var)
-  testthat::expect_true("year" %in% basic_gam_ys$first_derivative$var)
-  testthat::expect_true("year" %in% corrected_gam$first_derivative$var)
-  testthat::expect_true("year" %in% corrected_gam_ys$first_derivative$var)
+  # year column and baseline_observations, if present, contain numeric values
+  expect_true(is.numeric(basic_gam$first_derivative$year))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$year))
+  expect_true(is.numeric(corrected_gam$first_derivative$year))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$year))
+  expect_true(
+    is.numeric(corrected_gam$first_derivative$baseline_observations)
+  )
+  expect_true(
+    is.numeric(corrected_gam_ys$first_derivative$baseline_observations)
+  )
 
-  # if correction based on column baseline_observations, baseline_observations
-  # is present in var
-  testthat::expect_true("baseline_observations" %in% corrected_gam$first_derivative$var)
-  testthat::expect_true("baseline_observations" %in%
-    corrected_gam_ys$first_derivative$var)
-  testthat::expect_false("baseline_observations" %in% basic_gam$first_derivative$var)
-  testthat::expect_false("baseline_observations" %in% basic_gam_ys$first_derivative$var)
-
-  # data contains numeric values
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$data))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$data))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$data))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$data))
-
-  # data column is equal to column year of df_gam for basic gam
-  expect_equivalent(round(basic_gam$first_derivative$data),
+  # year column is equal to column year of df_gam for basic gam
+  expect_equivalent(round(basic_gam$first_derivative$year),
     expected = df_gam$year
   )
-  expect_equivalent(round(basic_gam_ys$first_derivative$data),
+  expect_equivalent(round(basic_gam_ys$first_derivative$year),
     expected = df_gam$year
   )
 
-  # columns derivative, se, crit, lower, upper are numeric
+  # columns derivative, se, crit, lower_ci, upper_ci are numeric
   testthat::expect_true(is.numeric(basic_gam$first_derivative$derivative))
   testthat::expect_true(is.numeric(basic_gam$first_derivative$se))
   testthat::expect_true(is.numeric(basic_gam$first_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$lower))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$upper))
+  testthat::expect_true(is.numeric(basic_gam$first_derivative$lower_ci))
+  testthat::expect_true(is.numeric(basic_gam$first_derivative$upper_ci))
   testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$derivative))
   testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$se))
   testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$lower))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$upper))
+  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$lower_ci))
+  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$upper_ci))
   testthat::expect_true(is.numeric(corrected_gam$first_derivative$derivative))
   testthat::expect_true(is.numeric(corrected_gam$first_derivative$se))
   testthat::expect_true(is.numeric(corrected_gam$first_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$lower))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$upper))
+  testthat::expect_true(is.numeric(corrected_gam$first_derivative$lower_ci))
+  testthat::expect_true(is.numeric(corrected_gam$first_derivative$upper_ci))
   testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$derivative))
   testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$se))
   testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$lower))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$upper))
+  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$lower_ci))
+  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$upper_ci))
 
   # number of evaluation years doesn't affect 1st derivative values
   testthat::expect_that(
@@ -635,31 +643,31 @@ testthat::test_that("Test first derivative", {
     testthat::is_identical_to(corrected_gam$first_derivative$crit)
   )
   testthat::expect_that(
-    basic_gam_ys$first_derivative$lower,
-    testthat::is_identical_to(basic_gam$first_derivative$lower)
+    basic_gam_ys$first_derivative$lower_ci,
+    testthat::is_identical_to(basic_gam$first_derivative$lower_ci)
   )
   testthat::expect_that(
-    corrected_gam$first_derivative$lower,
-    testthat::is_identical_to(corrected_gam$first_derivative$lower)
+    corrected_gam$first_derivative$lower_ci,
+    testthat::is_identical_to(corrected_gam$first_derivative$lower_ci)
   )
   testthat::expect_that(
-    basic_gam_ys$first_derivative$upper,
-    testthat::is_identical_to(basic_gam$first_derivative$upper)
+    basic_gam_ys$first_derivative$upper_ci,
+    testthat::is_identical_to(basic_gam$first_derivative$upper_ci)
   )
   testthat::expect_that(
-    corrected_gam$first_derivative$upper,
-    testthat::is_identical_to(corrected_gam$first_derivative$upper)
+    corrected_gam$first_derivative$upper_ci,
+    testthat::is_identical_to(corrected_gam$first_derivative$upper_ci)
   )
 
-  # lower <= derivative <= upper
-  testthat::expect_true(all(basic_gam$first_derivative$lower <=
+  # lower_ci <= derivative <= upper_ci
+  testthat::expect_true(all(basic_gam$first_derivative$lower_ci <=
     basic_gam$first_derivative$derivative &
     basic_gam$first_derivative$derivative <=
-      basic_gam$first_derivative$upper))
-  testthat::expect_true(all(corrected_gam$first_derivative$lower <=
+      basic_gam$first_derivative$upper_ci))
+  testthat::expect_true(all(corrected_gam$first_derivative$lower_ci <=
     corrected_gam$first_derivative$derivative &
     corrected_gam$first_derivative$derivative <=
-      corrected_gam$first_derivative$upper))
+      corrected_gam$first_derivative$upper_ci))
 })
 
 testthat::test_that("Test second derivative", {
@@ -675,25 +683,41 @@ testthat::test_that("Test second derivative", {
   expect_null(corrected_gam_bad_ys$second_derivative)
 
   # second derivatives has right columns
+  expected_cols_basic <- c(
+    "smooth",
+    "derivative",
+    "se",
+    "crit",
+    "lower_ci",
+    "upper_ci",
+    "year"
+  )
   testthat::expect_that(
     basic_gam$second_derivative,
-    has_names(expected = c(
-      "smooth",
-      "var",
-      "data",
-      "derivative",
-      "se",
-      "crit",
-      "lower",
-      "upper"
-    ))
+    has_names(expected = expected_cols_basic)
   )
-  testthat::expect_true(all(names(basic_gam$second_derivative) ==
-    names(basic_gam_ys$second_derivative)))
-  testthat::expect_true(all(names(basic_gam$second_derivative) ==
-    names(corrected_gam$second_derivative)))
-  testthat::expect_true(all(names(corrected_gam$second_derivative) ==
-    names(corrected_gam_ys$second_derivative)))
+  testthat::expect_that(
+    basic_gam_ys$second_derivative,
+    has_names(expected = expected_cols_basic)
+  )
+  expected_cols_corrected <- c(
+    "smooth",
+    "derivative",
+    "se",
+    "crit",
+    "lower_ci",
+    "upper_ci",
+    "year",
+    "baseline_observations"
+  )
+  testthat::expect_that(
+    corrected_gam$second_derivative,
+    has_names(expected = expected_cols_corrected)
+  )
+  testthat::expect_that(
+    corrected_gam_ys$second_derivative,
+    has_names(expected = expected_cols_corrected)
+  )
 
   # smooth column contains only s(year) for basic gam
   testthat::expect_true(unique(basic_gam$second_derivative$smooth) == "s(year)")
@@ -701,62 +725,47 @@ testthat::test_that("Test second derivative", {
   testthat::expect_false(all(unique(corrected_gam$second_derivative$smooth) == "s(year)"))
   testthat::expect_false(all(unique(corrected_gam_ys$second_derivative$smooth) == "s(year)"))
 
-  # smooth column contains s(year) and s(baseline_observations) if correction
-  # baseline is applied
-  testthat::expect_true(all(corrected_gam$second_derivative$smooth %in%
-    c("s(year)", "s(baseline_observations)")))
-  testthat::expect_true(all(corrected_gam_ys$second_derivative$smooth %in%
-    c("s(year)", "s(baseline_observations)")))
-
-  # var contains always value "year" if GAM is performed
-  testthat::expect_true("year" %in% basic_gam$second_derivative$var)
-  testthat::expect_true("year" %in% basic_gam_ys$second_derivative$var)
-  testthat::expect_true("year" %in% corrected_gam$second_derivative$var)
-  testthat::expect_true("year" %in% corrected_gam_ys$second_derivative$var)
-
-  # if correction based on column baseline_observations, baseline_observations
-  # is present in var
-  testthat::expect_true("baseline_observations" %in% corrected_gam$second_derivative$var)
-  testthat::expect_true("baseline_observations" %in%
-    corrected_gam_ys$second_derivative$var)
-  testthat::expect_false("baseline_observations" %in% basic_gam$second_derivative$var)
-  testthat::expect_false("baseline_observations" %in% basic_gam_ys$second_derivative$var)
-
-  # data contains numeric values
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$data))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$data))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$data))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$data))
-
-  # data column is equal to column year of df_gam for basic gam
-  expect_equivalent(round(basic_gam$second_derivative$data),
+  # year column and baseline_observations, if present, contain numeric values
+  expect_true(is.numeric(basic_gam$second_derivative$year))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$year))
+  expect_true(is.numeric(corrected_gam$second_derivative$year))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$year))
+  expect_true(
+    is.numeric(corrected_gam$second_derivative$baseline_observations)
+  )
+  expect_true(
+    is.numeric(corrected_gam_ys$second_derivative$baseline_observations)
+  )
+  
+  # year column is equal to column year of df_gam for basic gam
+  expect_equivalent(round(basic_gam$second_derivative$year),
     expected = df_gam$year
   )
-  expect_equivalent(round(basic_gam_ys$second_derivative$data),
+  expect_equivalent(round(basic_gam_ys$second_derivative$year),
     expected = df_gam$year
   )
 
-  # columns derivative, se, crit, lower, upper are numeric
+  # columns derivative, se, crit, lower_ci, upper_ci are numeric
   testthat::expect_true(is.numeric(basic_gam$second_derivative$derivative))
   testthat::expect_true(is.numeric(basic_gam$second_derivative$se))
   testthat::expect_true(is.numeric(basic_gam$second_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$lower))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$upper))
+  testthat::expect_true(is.numeric(basic_gam$second_derivative$lower_ci))
+  testthat::expect_true(is.numeric(basic_gam$second_derivative$upper_ci))
   testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$derivative))
   testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$se))
   testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$lower))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$upper))
+  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$lower_ci))
+  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$upper_ci))
   testthat::expect_true(is.numeric(corrected_gam$second_derivative$derivative))
   testthat::expect_true(is.numeric(corrected_gam$second_derivative$se))
   testthat::expect_true(is.numeric(corrected_gam$second_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$lower))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$upper))
+  testthat::expect_true(is.numeric(corrected_gam$second_derivative$lower_ci))
+  testthat::expect_true(is.numeric(corrected_gam$second_derivative$upper_ci))
   testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$derivative))
   testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$se))
   testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$lower))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$upper))
+  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$lower_ci))
+  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$upper_ci))
 
   # number of evaluation years doesn't affect 2nd derivative values
   testthat::expect_that(
@@ -784,31 +793,31 @@ testthat::test_that("Test second derivative", {
     testthat::is_identical_to(corrected_gam$second_derivative$crit)
   )
   testthat::expect_that(
-    basic_gam_ys$second_derivative$lower,
-    testthat::is_identical_to(basic_gam$second_derivative$lower)
+    basic_gam_ys$second_derivative$lower_ci,
+    testthat::is_identical_to(basic_gam$second_derivative$lower_ci)
   )
   testthat::expect_that(
-    corrected_gam$second_derivative$lower,
-    testthat::is_identical_to(corrected_gam$second_derivative$lower)
+    corrected_gam$second_derivative$lower_ci,
+    testthat::is_identical_to(corrected_gam$second_derivative$lower_ci)
   )
   testthat::expect_that(
-    basic_gam_ys$second_derivative$upper,
-    testthat::is_identical_to(basic_gam$second_derivative$upper)
+    basic_gam_ys$second_derivative$upper_ci,
+    testthat::is_identical_to(basic_gam$second_derivative$upper_ci)
   )
   testthat::expect_that(
-    corrected_gam$second_derivative$upper,
-    testthat::is_identical_to(corrected_gam$second_derivative$upper)
+    corrected_gam$second_derivative$upper_ci,
+    testthat::is_identical_to(corrected_gam$second_derivative$upper_ci)
   )
 
-  # lower <= derivative <= upper
-  testthat::expect_true(all(basic_gam$second_derivative$lower <=
+  # lower_ci <= derivative <= upper_ci
+  testthat::expect_true(all(basic_gam$second_derivative$lower_ci <=
     basic_gam$second_derivative$derivative &
     basic_gam$second_derivative$derivative <=
-      basic_gam$second_derivative$upper))
-  testthat::expect_true(all(corrected_gam$second_derivative$lower <=
+      basic_gam$second_derivative$upper_ci))
+  testthat::expect_true(all(corrected_gam$second_derivative$lower_ci <=
     corrected_gam$second_derivative$derivative &
     corrected_gam$second_derivative$derivative <=
-      corrected_gam$second_derivative$upper))
+      corrected_gam$second_derivative$upper_ci))
 })
 
 testthat::test_that("Test plot", {

--- a/tests/testthat/test-output_apply_gam.R
+++ b/tests/testthat/test-output_apply_gam.R
@@ -144,78 +144,78 @@ basic_gam_taxon_key_and_name <- apply_gam(
   taxon_key = taxon_key
 )
 
-testthat::test_that("Test length of output list", {
+test_that("Test length of output list", {
   # length of list output is not dependent on GAM output
-  testthat::expect_equal(length(basic_gam), expected = 6)
-  testthat::expect_equal(length(corrected_gam), expected = 6)
-  testthat::expect_equal(length(basic_gam_bad), expected = 6)
-  testthat::expect_equal(length(corrected_gam_bad), expected = 6)
+  expect_equal(length(basic_gam), expected = 6)
+  expect_equal(length(corrected_gam), expected = 6)
+  expect_equal(length(basic_gam_bad), expected = 6)
+  expect_equal(length(corrected_gam_bad), expected = 6)
 })
 
-testthat::test_that("Test em_summary", {
+test_that("Test em_summary", {
   # em_summary is a data.frame
-  testthat::expect_true(is.data.frame(basic_gam$em_summary))
-  testthat::expect_true(is.data.frame(basic_gam_ys$em_summary))
-  testthat::expect_true(is.data.frame(basic_gam_bad$em_summary))
-  testthat::expect_true(is.data.frame(basic_gam_bad_ys$em_summary))
-  testthat::expect_true(is.data.frame(corrected_gam$em_summary))
-  testthat::expect_true(is.data.frame(corrected_gam_ys$em_summary))
-  testthat::expect_true(is.data.frame(corrected_gam_bad$em_summary))
-  testthat::expect_true(is.data.frame(corrected_gam_bad_ys$em_summary))
+  expect_true(is.data.frame(basic_gam$em_summary))
+  expect_true(is.data.frame(basic_gam_ys$em_summary))
+  expect_true(is.data.frame(basic_gam_bad$em_summary))
+  expect_true(is.data.frame(basic_gam_bad_ys$em_summary))
+  expect_true(is.data.frame(corrected_gam$em_summary))
+  expect_true(is.data.frame(corrected_gam_ys$em_summary))
+  expect_true(is.data.frame(corrected_gam_bad$em_summary))
+  expect_true(is.data.frame(corrected_gam_bad_ys$em_summary))
   # evaluation on one year
-  testthat::expect_equal(nrow(basic_gam$em_summary),
+  expect_equal(nrow(basic_gam$em_summary),
     expected = length(evaluation_year)
   )
-  testthat::expect_equal(nrow(corrected_gam$em_summary),
+  expect_equal(nrow(corrected_gam$em_summary),
     expected = length(evaluation_year)
   )
-  testthat::expect_equal(nrow(basic_gam_bad$em_summary),
+  expect_equal(nrow(basic_gam_bad$em_summary),
     expected = length(evaluation_year)
   )
-  testthat::expect_equal(nrow(corrected_gam_bad$em_summary),
+  expect_equal(nrow(corrected_gam_bad$em_summary),
     expected = length(evaluation_year)
   )
   # evaluation on two years
-  testthat::expect_equal(nrow(basic_gam_ys$em_summary),
+  expect_equal(nrow(basic_gam_ys$em_summary),
     expected = length(evaluation_years)
   )
-  testthat::expect_equal(nrow(corrected_gam_ys$em_summary),
+  expect_equal(nrow(corrected_gam_ys$em_summary),
     expected = length(evaluation_years)
   )
-  testthat::expect_equal(nrow(basic_gam_bad_ys$em_summary),
+  expect_equal(nrow(basic_gam_bad_ys$em_summary),
     expected = length(evaluation_years)
   )
-  testthat::expect_equal(nrow(corrected_gam_bad_ys$em_summary),
+  expect_equal(nrow(corrected_gam_bad_ys$em_summary),
     expected = length(evaluation_years)
   )
   # if GAM cannot be performed, em_summary and growth are NA
-  testthat::expect_true(all(
+  expect_true(all(
     is.na(corrected_gam_bad$em_summary$em_status),
     is.na(corrected_gam_bad$em_summary$growth),
     is.na(corrected_gam_bad_ys$em_summary$em_status),
     is.na(corrected_gam_bad_ys$em_summary$growth)
   ))
   # if GAM is performed em_summary and growth are numeric
-  testthat::expect_true(all(
+  expect_true(all(
     is.numeric(corrected_gam$em_summary$em_status),
     is.numeric(corrected_gam$em_summary$growth),
     is.numeric(corrected_gam_ys$em_summary$em_status),
     is.numeric(corrected_gam_ys$em_summary$growth)
   ))
   # if GAM is performed em_summary is one of 0,1,2,3
-  testthat::expect_true(all(
+  expect_true(all(
     corrected_gam$em_summary$em_status %in% c(0, 1, 2, 3),
     corrected_gam_ys$em_summary$em_status %in% c(0, 1, 2, 3)
   ))
 })
 
-testthat::test_that("Test model", {
+test_that("Test model", {
 
   # model output is an instance of class "gam"
-  testthat::expect_true(all(class(basic_gam$model) == c("gam", "glm", "lm")))
-  testthat::expect_true(all(class(basic_gam_ys$model) == c("gam", "glm", "lm")))
-  testthat::expect_true(all(class(corrected_gam$model) == c("gam", "glm", "lm")))
-  testthat::expect_true(all(class(corrected_gam_ys$model) == c("gam", "glm", "lm")))
+  expect_true(all(class(basic_gam$model) == c("gam", "glm", "lm")))
+  expect_true(all(class(basic_gam_ys$model) == c("gam", "glm", "lm")))
+  expect_true(all(class(corrected_gam$model) == c("gam", "glm", "lm")))
+  expect_true(all(class(corrected_gam_ys$model) == c("gam", "glm", "lm")))
 
   # model output is NULL if gam is not performed
   expect_null(basic_gam_bad$model)
@@ -224,112 +224,112 @@ testthat::test_that("Test model", {
   expect_null(corrected_gam_bad_ys$model)
 
   # model formula is correct
-  testthat::expect_true(all(
+  expect_true(all(
     basic_gam$model$formula == basic_fm,
     basic_gam_ys$model$formula == basic_fm
   ))
-  testthat::expect_true(all(
+  expect_true(all(
     corrected_gam$model$formula == corrected_fm,
     corrected_gam_ys$model$formula == corrected_fm
   ))
 })
 
-testthat::test_that("Test output", {
+test_that("Test output", {
 
   # output is a data.frame
-  testthat::expect_true(is.data.frame(basic_gam$output))
-  testthat::expect_true(is.data.frame(basic_gam_ys$output))
-  testthat::expect_true(is.data.frame(basic_gam_bad$output))
-  testthat::expect_true(is.data.frame(basic_gam_bad_ys$output))
-  testthat::expect_true(is.data.frame(corrected_gam$output))
-  testthat::expect_true(is.data.frame(corrected_gam_ys$output))
-  testthat::expect_true(is.data.frame(corrected_gam_bad$output))
-  testthat::expect_true(is.data.frame(corrected_gam_bad_ys$output))
+  expect_true(is.data.frame(basic_gam$output))
+  expect_true(is.data.frame(basic_gam_ys$output))
+  expect_true(is.data.frame(basic_gam_bad$output))
+  expect_true(is.data.frame(basic_gam_bad_ys$output))
+  expect_true(is.data.frame(corrected_gam$output))
+  expect_true(is.data.frame(corrected_gam_ys$output))
+  expect_true(is.data.frame(corrected_gam_bad$output))
+  expect_true(is.data.frame(corrected_gam_bad_ys$output))
   # output has all columns of input df
-  testthat::expect_true(all(names(df_gam) %in% names(basic_gam$output)))
-  testthat::expect_true(all(names(df_gam) %in% names(basic_gam_ys$output)))
-  testthat::expect_true(all(names(df_bad) %in% names(basic_gam_bad$output)))
-  testthat::expect_true(all(names(df_bad) %in% names(basic_gam_bad_ys$output)))
-  testthat::expect_true(all(names(df_gam) %in% names(corrected_gam$output)))
-  testthat::expect_true(all(names(df_gam) %in% names(corrected_gam_ys$output)))
-  testthat::expect_true(all(names(df_bad) %in% names(corrected_gam_bad$output)))
-  testthat::expect_true(all(names(df_bad) %in% names(corrected_gam_bad_ys$output)))
+  expect_true(all(names(df_gam) %in% names(basic_gam$output)))
+  expect_true(all(names(df_gam) %in% names(basic_gam_ys$output)))
+  expect_true(all(names(df_bad) %in% names(basic_gam_bad$output)))
+  expect_true(all(names(df_bad) %in% names(basic_gam_bad_ys$output)))
+  expect_true(all(names(df_gam) %in% names(corrected_gam$output)))
+  expect_true(all(names(df_gam) %in% names(corrected_gam_ys$output)))
+  expect_true(all(names(df_bad) %in% names(corrected_gam_bad$output)))
+  expect_true(all(names(df_bad) %in% names(corrected_gam_bad_ys$output)))
 
   # values of these columns are also identical
-  testthat::expect_true(all(df_gam$taxonKey == basic_gam$output$taxonKey))
-  testthat::expect_true(all(df_gam$taxonKey == basic_gam_ys$output$taxonKey))
-  testthat::expect_true(all(df_bad$taxonKey == basic_gam_bad$output$taxonKey))
-  testthat::expect_true(all(df_bad$taxonKey == basic_gam_bad_ys$output$taxonKey))
-  testthat::expect_true(all(df_gam$taxonKey == corrected_gam$output$taxonKey))
-  testthat::expect_true(all(df_gam$taxonKey == corrected_gam_ys$output$taxonKey))
-  testthat::expect_true(all(df_bad$taxonKey == corrected_gam_bad$output$taxonKey))
-  testthat::expect_true(all(df_bad$taxonKey == corrected_gam_bad_ys$output$taxonKey))
-  testthat::expect_true(all(df_gam$canonicalName == basic_gam$output$canonicalName))
-  testthat::expect_true(all(df_gam$canonicalName == basic_gam_ys$output$canonicalName))
-  testthat::expect_true(all(df_bad$canonicalName == basic_gam_bad$output$canonicalName))
-  testthat::expect_true(all(df_bad$canonicalName ==
+  expect_true(all(df_gam$taxonKey == basic_gam$output$taxonKey))
+  expect_true(all(df_gam$taxonKey == basic_gam_ys$output$taxonKey))
+  expect_true(all(df_bad$taxonKey == basic_gam_bad$output$taxonKey))
+  expect_true(all(df_bad$taxonKey == basic_gam_bad_ys$output$taxonKey))
+  expect_true(all(df_gam$taxonKey == corrected_gam$output$taxonKey))
+  expect_true(all(df_gam$taxonKey == corrected_gam_ys$output$taxonKey))
+  expect_true(all(df_bad$taxonKey == corrected_gam_bad$output$taxonKey))
+  expect_true(all(df_bad$taxonKey == corrected_gam_bad_ys$output$taxonKey))
+  expect_true(all(df_gam$canonicalName == basic_gam$output$canonicalName))
+  expect_true(all(df_gam$canonicalName == basic_gam_ys$output$canonicalName))
+  expect_true(all(df_bad$canonicalName == basic_gam_bad$output$canonicalName))
+  expect_true(all(df_bad$canonicalName ==
     basic_gam_bad_ys$output$canonicalName))
-  testthat::expect_true(all(df_gam$canonicalName == corrected_gam$output$canonicalName))
-  testthat::expect_true(all(df_gam$canonicalName == corrected_gam_ys$output$canonicalName))
-  testthat::expect_true(all(df_bad$canonicalName == corrected_gam_bad$output$canonicalName))
-  testthat::expect_true(all(df_bad$canonicalName ==
+  expect_true(all(df_gam$canonicalName == corrected_gam$output$canonicalName))
+  expect_true(all(df_gam$canonicalName == corrected_gam_ys$output$canonicalName))
+  expect_true(all(df_bad$canonicalName == corrected_gam_bad$output$canonicalName))
+  expect_true(all(df_bad$canonicalName ==
     corrected_gam_bad_ys$output$canonicalName))
-  testthat::expect_true(all(df_gam$year == basic_gam$output$year))
-  testthat::expect_true(all(df_gam$year == basic_gam_ys$output$year))
-  testthat::expect_true(all(df_bad$year == basic_gam_bad$output$year))
-  testthat::expect_true(all(df_bad$year == basic_gam_bad_ys$output$year))
-  testthat::expect_true(all(df_gam$year == corrected_gam$output$year))
-  testthat::expect_true(all(df_gam$year == corrected_gam_ys$output$year))
-  testthat::expect_true(all(df_bad$year == corrected_gam_bad$output$year))
-  testthat::expect_true(all(df_bad$year == corrected_gam_bad_ys$output$year))
-  testthat::expect_true(all(df_gam$n_observations == basic_gam$output$n_observations))
-  testthat::expect_true(all(df_gam$n_observations == basic_gam_ys$output$n_observations))
-  testthat::expect_true(all(df_bad$n_observations == basic_gam_bad$output$n_observations))
-  testthat::expect_true(all(df_bad$n_observations ==
+  expect_true(all(df_gam$year == basic_gam$output$year))
+  expect_true(all(df_gam$year == basic_gam_ys$output$year))
+  expect_true(all(df_bad$year == basic_gam_bad$output$year))
+  expect_true(all(df_bad$year == basic_gam_bad_ys$output$year))
+  expect_true(all(df_gam$year == corrected_gam$output$year))
+  expect_true(all(df_gam$year == corrected_gam_ys$output$year))
+  expect_true(all(df_bad$year == corrected_gam_bad$output$year))
+  expect_true(all(df_bad$year == corrected_gam_bad_ys$output$year))
+  expect_true(all(df_gam$n_observations == basic_gam$output$n_observations))
+  expect_true(all(df_gam$n_observations == basic_gam_ys$output$n_observations))
+  expect_true(all(df_bad$n_observations == basic_gam_bad$output$n_observations))
+  expect_true(all(df_bad$n_observations ==
     basic_gam_bad_ys$output$n_observations))
-  testthat::expect_true(all(df_gam$n_observations == corrected_gam$output$n_observations))
-  testthat::expect_true(all(df_gam$n_observations == corrected_gam_ys$output$n_observations))
-  testthat::expect_true(all(df_bad$n_observations == corrected_gam_bad$output$n_observations))
-  testthat::expect_true(all(df_bad$n_observations ==
+  expect_true(all(df_gam$n_observations == corrected_gam$output$n_observations))
+  expect_true(all(df_gam$n_observations == corrected_gam_ys$output$n_observations))
+  expect_true(all(df_bad$n_observations == corrected_gam_bad$output$n_observations))
+  expect_true(all(df_bad$n_observations ==
     corrected_gam_bad_ys$output$n_observations))
 
-  testthat::expect_true(all(df_gam$baseline_observations ==
+  expect_true(all(df_gam$baseline_observations ==
     basic_gam$output$baseline_observations))
-  testthat::expect_true(all(df_gam$baseline_observations ==
+  expect_true(all(df_gam$baseline_observations ==
     basic_gam_ys$output$baseline_observations))
-  testthat::expect_true(all(df_bad$baseline_observations ==
+  expect_true(all(df_bad$baseline_observations ==
     basic_gam_bad$output$baseline_observations))
-  testthat::expect_true(all(df_bad$baseline_observations ==
+  expect_true(all(df_bad$baseline_observations ==
     basic_gam_bad_ys$output$baseline_observations))
-  testthat::expect_true(all(df_gam$baseline_observations ==
+  expect_true(all(df_gam$baseline_observations ==
     corrected_gam$output$baseline_observations))
-  testthat::expect_true(all(df_gam$baseline_observations ==
+  expect_true(all(df_gam$baseline_observations ==
     corrected_gam_ys$output$baseline_observations))
-  testthat::expect_true(all(df_bad$baseline_observations ==
+  expect_true(all(df_bad$baseline_observations ==
     corrected_gam_bad$output$baseline_observations))
-  testthat::expect_true(all(df_bad$baseline_observations ==
+  expect_true(all(df_bad$baseline_observations ==
     corrected_gam_bad_ys$output$baseline_observations))
 
   # output has columns em1, em2, em, em_status, growth, method
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(basic_gam$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(basic_gam_ys$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(basic_gam_bad$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(basic_gam_bad_ys$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(corrected_gam$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(corrected_gam_ys$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(corrected_gam_bad$output)))
-  testthat::expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
+  expect_true(all(c("em1", "em2", "em", "em_status", "growth", "method") %in%
     names(corrected_gam_bad_ys$output)))
 
   # fit values are zero or above
-  testthat::expect_true(all(c(
+  expect_true(all(c(
     basic_gam$output$fit,
     basic_gam$output$ucl,
     basic_gam$output$lcl,
@@ -337,7 +337,7 @@ testthat::test_that("Test output", {
     corrected_gam$output$ucl,
     corrected_gam$output$lcl
   ) >= 0))
-  testthat::expect_true(all(c(
+  expect_true(all(c(
     basic_gam_ys$output$fit,
     basic_gam_ys$output$ucl,
     basic_gam_ys$output$lcl,
@@ -347,7 +347,7 @@ testthat::test_that("Test output", {
   ) >= 0))
 
   # if GAM is not performed: fit columns are NA
-  testthat::expect_true(all(is.na(c(
+  expect_true(all(is.na(c(
     basic_gam_bad$output$fit,
     basic_gam_bad$output$ucl,
     basic_gam_bad$output$lcl,
@@ -355,7 +355,7 @@ testthat::test_that("Test output", {
     corrected_gam_bad$output$ucl,
     corrected_gam_bad$output$lcl
   ))))
-  testthat::expect_true(all(is.na(c(
+  expect_true(all(is.na(c(
     basic_gam_bad_ys$output$fit,
     basic_gam_bad_ys$output$ucl,
     basic_gam_bad_ys$output$lcl,
@@ -365,121 +365,121 @@ testthat::test_that("Test output", {
   ))))
 
   # lcl <= fit <= ucl
-  testthat::expect_true(all(basic_gam$output$lcl <= basic_gam$output$fit &
+  expect_true(all(basic_gam$output$lcl <= basic_gam$output$fit &
     basic_gam$output$fit <= basic_gam$output$ucl))
-  testthat::expect_true(all(basic_gam_ys$output$lcl <= basic_gam_ys$output$fit &
+  expect_true(all(basic_gam_ys$output$lcl <= basic_gam_ys$output$fit &
     basic_gam_ys$output$fit <= basic_gam_ys$output$ucl))
-  testthat::expect_true(all(corrected_gam$output$lcl <= corrected_gam$output$fit &
+  expect_true(all(corrected_gam$output$lcl <= corrected_gam$output$fit &
     corrected_gam$output$fit <= corrected_gam$output$ucl))
-  testthat::expect_true(all(corrected_gam_ys$output$lcl <= corrected_gam_ys$output$fit &
+  expect_true(all(corrected_gam_ys$output$lcl <= corrected_gam_ys$output$fit &
     corrected_gam_ys$output$fit <= corrected_gam_ys$output$ucl))
 
   # number of years for evaluation doesn't affect fit values
-  testthat::expect_true(all(basic_gam$output$lcl == basic_gam_ys$output$lcl &
+  expect_true(all(basic_gam$output$lcl == basic_gam_ys$output$lcl &
     basic_gam$output$fit == basic_gam_ys$output$fit &
     basic_gam$output$ucl == basic_gam_ys$output$ucl))
-  testthat::expect_true(all(corrected_gam$output$lcl == corrected_gam_ys$output$lcl &
+  expect_true(all(corrected_gam$output$lcl == corrected_gam_ys$output$lcl &
     corrected_gam$output$fit == corrected_gam_ys$output$fit &
     corrected_gam$output$ucl == corrected_gam_ys$output$ucl))
 
   # em1, em2, em, em_status are numeric
-  testthat::expect_true(is.numeric(basic_gam$output$em1))
-  testthat::expect_true(is.numeric(basic_gam$output$em2))
-  testthat::expect_true(is.numeric(basic_gam$output$em))
-  testthat::expect_true(is.numeric(basic_gam$output$em_status))
-  testthat::expect_true(is.numeric(corrected_gam$output$em1))
-  testthat::expect_true(is.numeric(corrected_gam$output$em2))
-  testthat::expect_true(is.numeric(corrected_gam$output$em))
-  testthat::expect_true(is.numeric(corrected_gam$output$em_status))
-  testthat::expect_true(is.numeric(basic_gam_bad$output$em1))
-  testthat::expect_true(is.numeric(basic_gam_bad$output$em2))
-  testthat::expect_true(is.numeric(basic_gam_bad$output$em))
-  testthat::expect_true(is.numeric(basic_gam_bad$output$em_status))
-  testthat::expect_true(is.numeric(corrected_gam_bad$output$em1))
-  testthat::expect_true(is.numeric(corrected_gam_bad$output$em2))
-  testthat::expect_true(is.numeric(corrected_gam_bad$output$em))
-  testthat::expect_true(is.numeric(corrected_gam_bad$output$em_status))
+  expect_true(is.numeric(basic_gam$output$em1))
+  expect_true(is.numeric(basic_gam$output$em2))
+  expect_true(is.numeric(basic_gam$output$em))
+  expect_true(is.numeric(basic_gam$output$em_status))
+  expect_true(is.numeric(corrected_gam$output$em1))
+  expect_true(is.numeric(corrected_gam$output$em2))
+  expect_true(is.numeric(corrected_gam$output$em))
+  expect_true(is.numeric(corrected_gam$output$em_status))
+  expect_true(is.numeric(basic_gam_bad$output$em1))
+  expect_true(is.numeric(basic_gam_bad$output$em2))
+  expect_true(is.numeric(basic_gam_bad$output$em))
+  expect_true(is.numeric(basic_gam_bad$output$em_status))
+  expect_true(is.numeric(corrected_gam_bad$output$em1))
+  expect_true(is.numeric(corrected_gam_bad$output$em2))
+  expect_true(is.numeric(corrected_gam_bad$output$em))
+  expect_true(is.numeric(corrected_gam_bad$output$em_status))
 
   # if GAM is performed em1 em2 are one of c(-1, 0, 1),
-  testthat::expect_true(all(
+  expect_true(all(
     basic_gam$output$em1 %in% c(-1, 0, 1),
     basic_gam$output$em2 %in% c(-1, 0, 1)
   ))
-  testthat::expect_true(all(
+  expect_true(all(
     basic_gam_ys$output$em1 %in% c(-1, 0, 1),
     basic_gam_ys$output$em2 %in% c(-1, 0, 1)
   ))
-  testthat::expect_true(all(
+  expect_true(all(
     corrected_gam$output$em1 %in% c(-1, 0, 1),
     corrected_gam$output$em2 %in% c(-1, 0, 1)
   ))
-  testthat::expect_true(all(
+  expect_true(all(
     corrected_gam_ys$output$em1 %in% c(-1, 0, 1),
     corrected_gam_ys$output$em2 %in% c(-1, 0, 1)
   ))
 
   # if GAM is performed em is a value between -4 and +4
-  testthat::expect_true(all(basic_gam$output$em <= 4 & basic_gam$output$em >= -4))
-  testthat::expect_true(all(basic_gam_ys$output$em <= 4 & basic_gam$output$em >= -4))
-  testthat::expect_true(all(corrected_gam$output$em <= 4 & basic_gam$output$em >= -4))
-  testthat::expect_true(all(corrected_gam_ys$output$em <= 4 & basic_gam$output$em >= -4))
+  expect_true(all(basic_gam$output$em <= 4 & basic_gam$output$em >= -4))
+  expect_true(all(basic_gam_ys$output$em <= 4 & basic_gam$output$em >= -4))
+  expect_true(all(corrected_gam$output$em <= 4 & basic_gam$output$em >= -4))
+  expect_true(all(corrected_gam_ys$output$em <= 4 & basic_gam$output$em >= -4))
 
   # if GAM is performed em_stauts is one of 0, 1, 2, 3
-  testthat::expect_true(all(basic_gam$output$em_status <= 3 &
+  expect_true(all(basic_gam$output$em_status <= 3 &
     basic_gam$output$em_status >= 0))
-  testthat::expect_true(all(basic_gam_ys$output$em_status <= 3 &
+  expect_true(all(basic_gam_ys$output$em_status <= 3 &
     basic_gam_ys$output$em_status >= 0))
-  testthat::expect_true(all(corrected_gam$output$em_status <= 3 &
+  expect_true(all(corrected_gam$output$em_status <= 3 &
     corrected_gam$output$em_status >= 0))
-  testthat::expect_true(all(corrected_gam_ys$output$em_status <= 3 &
+  expect_true(all(corrected_gam_ys$output$em_status <= 3 &
     corrected_gam_ys$output$em_status >= 0))
 
   # em_status is equal to em_summary for evaluation_years
-  testthat::expect_true(all((basic_gam$output %>%
+  expect_true(all((basic_gam$output %>%
     dplyr::filter(year == evaluation_year) %>%
     pull(em_status)) ==
     (basic_gam$em_summary %>%
       dplyr::filter(year == evaluation_year) %>%
       pull(em_status))))
-  testthat::expect_true(all((basic_gam_ys$output %>%
+  expect_true(all((basic_gam_ys$output %>%
     dplyr::filter(year %in% evaluation_years) %>%
     pull(em_status)) ==
     (basic_gam_ys$em_summary %>%
       dplyr::filter(year %in% evaluation_years) %>%
       pull(em_status))))
-  testthat::expect_true(all((corrected_gam$output %>%
+  expect_true(all((corrected_gam$output %>%
     dplyr::filter(year == evaluation_year) %>%
     pull(em_status)) ==
     (corrected_gam$em_summary %>%
       dplyr::filter(year == evaluation_year) %>%
       pull(em_status))))
-  testthat::expect_true(all((corrected_gam_ys$output %>%
+  expect_true(all((corrected_gam_ys$output %>%
     dplyr::filter(year %in% evaluation_years) %>%
     pull(em_status)) ==
     (corrected_gam_ys$em_summary %>%
       dplyr::filter(year %in% evaluation_years) %>%
       pull(em_status))))
-  testthat::expect_true(all(is.na(corrected_gam_bad$output %>%
+  expect_true(all(is.na(corrected_gam_bad$output %>%
     dplyr::filter(year == evaluation_year) %>%
     pull(em_status))))
-  testthat::expect_true(all(is.na(corrected_gam_bad_ys$output %>%
+  expect_true(all(is.na(corrected_gam_bad_ys$output %>%
     dplyr::filter(year %in% evaluation_years) %>%
     pull(em_status))))
-  testthat::expect_true(all(is.na(corrected_gam_bad$output %>%
+  expect_true(all(is.na(corrected_gam_bad$output %>%
     dplyr::filter(year == evaluation_year) %>%
     pull(em_status))))
-  testthat::expect_true(all(is.na(corrected_gam_bad_ys$output %>%
+  expect_true(all(is.na(corrected_gam_bad_ys$output %>%
     dplyr::filter(year %in% evaluation_years) %>%
     pull(em_status))))
 
   # number of years for evaluation doesn't affect em1, em2, em, em_status
-  testthat::expect_true(all(
+  expect_true(all(
     basic_gam$output$em1 == basic_gam_ys$output$em1,
     basic_gam$output$em2 == basic_gam_ys$output$em2,
     basic_gam$output$em == basic_gam_ys$output$em,
     basic_gam$output$em_status == corrected_gam_ys$output$em_status
   ))
-  testthat::expect_true(all(
+  expect_true(all(
     corrected_gam_ys$output$em1 == corrected_gam_ys$output$em1,
     corrected_gam_ys$output$em2 == corrected_gam_ys$output$em2,
     corrected_gam_ys$output$em == corrected_gam_ys$output$em,
@@ -487,25 +487,25 @@ testthat::test_that("Test output", {
   ))
 
   # growth
-  testthat::expect_true(is.numeric(basic_gam$output$growth))
-  testthat::expect_true(is.numeric(basic_gam_ys$output$growth))
-  testthat::expect_true(is.numeric(basic_gam_bad$output$growth))
-  testthat::expect_true(is.numeric(basic_gam_bad_ys$output$growth))
-  testthat::expect_true(is.numeric(corrected_gam$output$growth))
-  testthat::expect_true(is.numeric(corrected_gam_ys$output$growth))
-  testthat::expect_true(is.numeric(corrected_gam_bad$output$growth))
-  testthat::expect_true(is.numeric(corrected_gam_bad_ys$output$growth))
+  expect_true(is.numeric(basic_gam$output$growth))
+  expect_true(is.numeric(basic_gam_ys$output$growth))
+  expect_true(is.numeric(basic_gam_bad$output$growth))
+  expect_true(is.numeric(basic_gam_bad_ys$output$growth))
+  expect_true(is.numeric(corrected_gam$output$growth))
+  expect_true(is.numeric(corrected_gam_ys$output$growth))
+  expect_true(is.numeric(corrected_gam_bad$output$growth))
+  expect_true(is.numeric(corrected_gam_bad_ys$output$growth))
 
   # add some checks about values of growth?
 
   # method is correctly returned
-  testthat::expect_true(all(c(
+  expect_true(all(c(
     basic_gam$output$method,
     basic_gam_bad$output$method,
     basic_gam_ys$output$method,
     basic_gam_bad_ys$output$method
   ) == "basic"))
-  testthat::expect_true(all(c(
+  expect_true(all(c(
     corrected_gam$output$method,
     corrected_gam_bad$output$method,
     corrected_gam_ys$output$method,
@@ -513,13 +513,13 @@ testthat::test_that("Test output", {
   ) == "correct_baseline"))
 })
 
-testthat::test_that("Test first derivative", {
+test_that("Test first derivative", {
 
   # first derivative is a data.frame or is NULL
-  testthat::expect_true(is.data.frame(basic_gam$first_derivative))
-  testthat::expect_true(is.data.frame(basic_gam_ys$first_derivative))
-  testthat::expect_true(is.data.frame(corrected_gam$first_derivative))
-  testthat::expect_true(is.data.frame(corrected_gam_ys$first_derivative))
+  expect_true(is.data.frame(basic_gam$first_derivative))
+  expect_true(is.data.frame(basic_gam_ys$first_derivative))
+  expect_true(is.data.frame(corrected_gam$first_derivative))
+  expect_true(is.data.frame(corrected_gam_ys$first_derivative))
   expect_null(basic_gam_bad$first_derivative)
   expect_null(basic_gam_bad_ys$first_derivative)
   expect_null(corrected_gam_bad$first_derivative)
@@ -535,11 +535,11 @@ testthat::test_that("Test first derivative", {
     "upper_ci",
     "year"
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam$first_derivative,
     has_names(expected = expected_cols_basic)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative,
     has_names(expected = expected_cols_basic)
   )
@@ -553,26 +553,26 @@ testthat::test_that("Test first derivative", {
     "year",
     "baseline_observations"
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative,
     has_names(expected = expected_cols_corrected)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam_ys$first_derivative,
     has_names(expected = expected_cols_corrected)
   )
   
   # smooth column contains only s(year) for basic gam
-  testthat::expect_true(unique(basic_gam$first_derivative$smooth) == "s(year)")
-  testthat::expect_true(unique(basic_gam_ys$first_derivative$smooth) == "s(year)")
-  testthat::expect_false(all(unique(corrected_gam$first_derivative$smooth) == "s(year)"))
-  testthat::expect_false(all(unique(corrected_gam_ys$first_derivative$smooth) == "s(year)"))
+  expect_true(unique(basic_gam$first_derivative$smooth) == "s(year)")
+  expect_true(unique(basic_gam_ys$first_derivative$smooth) == "s(year)")
+  expect_false(all(unique(corrected_gam$first_derivative$smooth) == "s(year)"))
+  expect_false(all(unique(corrected_gam_ys$first_derivative$smooth) == "s(year)"))
 
   # smooth column contains s(year) and s(baseline_observations) if correction
   # baseline is applied
-  testthat::expect_true(all(corrected_gam$first_derivative$smooth %in%
+  expect_true(all(corrected_gam$first_derivative$smooth %in%
     c("s(year)", "s(baseline_observations)")))
-  testthat::expect_true(all(corrected_gam_ys$first_derivative$smooth %in%
+  expect_true(all(corrected_gam_ys$first_derivative$smooth %in%
     c("s(year)", "s(baseline_observations)")))
 
   # year column and baseline_observations, if present, contain numeric values
@@ -596,87 +596,87 @@ testthat::test_that("Test first derivative", {
   )
 
   # columns derivative, se, crit, lower_ci, upper_ci are numeric
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$derivative))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$se))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$lower_ci))
-  testthat::expect_true(is.numeric(basic_gam$first_derivative$upper_ci))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$derivative))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$se))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$lower_ci))
-  testthat::expect_true(is.numeric(basic_gam_ys$first_derivative$upper_ci))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$derivative))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$se))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$lower_ci))
-  testthat::expect_true(is.numeric(corrected_gam$first_derivative$upper_ci))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$derivative))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$se))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$lower_ci))
-  testthat::expect_true(is.numeric(corrected_gam_ys$first_derivative$upper_ci))
+  expect_true(is.numeric(basic_gam$first_derivative$derivative))
+  expect_true(is.numeric(basic_gam$first_derivative$se))
+  expect_true(is.numeric(basic_gam$first_derivative$crit))
+  expect_true(is.numeric(basic_gam$first_derivative$lower_ci))
+  expect_true(is.numeric(basic_gam$first_derivative$upper_ci))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$derivative))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$se))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$crit))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$lower_ci))
+  expect_true(is.numeric(basic_gam_ys$first_derivative$upper_ci))
+  expect_true(is.numeric(corrected_gam$first_derivative$derivative))
+  expect_true(is.numeric(corrected_gam$first_derivative$se))
+  expect_true(is.numeric(corrected_gam$first_derivative$crit))
+  expect_true(is.numeric(corrected_gam$first_derivative$lower_ci))
+  expect_true(is.numeric(corrected_gam$first_derivative$upper_ci))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$derivative))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$se))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$crit))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$lower_ci))
+  expect_true(is.numeric(corrected_gam_ys$first_derivative$upper_ci))
 
   # number of evaluation years doesn't affect 1st derivative values
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative$derivative,
-    testthat::is_identical_to(basic_gam$first_derivative$derivative)
+    is_identical_to(basic_gam$first_derivative$derivative)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative$derivative,
-    testthat::is_identical_to(corrected_gam$first_derivative$derivative)
+    is_identical_to(corrected_gam$first_derivative$derivative)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative$se,
-    testthat::is_identical_to(basic_gam$first_derivative$se)
+    is_identical_to(basic_gam$first_derivative$se)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative$se,
-    testthat::is_identical_to(corrected_gam$first_derivative$se)
+    is_identical_to(corrected_gam$first_derivative$se)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative$crit,
-    testthat::is_identical_to(basic_gam$first_derivative$crit)
+    is_identical_to(basic_gam$first_derivative$crit)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative$crit,
-    testthat::is_identical_to(corrected_gam$first_derivative$crit)
+    is_identical_to(corrected_gam$first_derivative$crit)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative$lower_ci,
-    testthat::is_identical_to(basic_gam$first_derivative$lower_ci)
+    is_identical_to(basic_gam$first_derivative$lower_ci)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative$lower_ci,
-    testthat::is_identical_to(corrected_gam$first_derivative$lower_ci)
+    is_identical_to(corrected_gam$first_derivative$lower_ci)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$first_derivative$upper_ci,
-    testthat::is_identical_to(basic_gam$first_derivative$upper_ci)
+    is_identical_to(basic_gam$first_derivative$upper_ci)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$first_derivative$upper_ci,
-    testthat::is_identical_to(corrected_gam$first_derivative$upper_ci)
+    is_identical_to(corrected_gam$first_derivative$upper_ci)
   )
 
   # lower_ci <= derivative <= upper_ci
-  testthat::expect_true(all(basic_gam$first_derivative$lower_ci <=
+  expect_true(all(basic_gam$first_derivative$lower_ci <=
     basic_gam$first_derivative$derivative &
     basic_gam$first_derivative$derivative <=
       basic_gam$first_derivative$upper_ci))
-  testthat::expect_true(all(corrected_gam$first_derivative$lower_ci <=
+  expect_true(all(corrected_gam$first_derivative$lower_ci <=
     corrected_gam$first_derivative$derivative &
     corrected_gam$first_derivative$derivative <=
       corrected_gam$first_derivative$upper_ci))
 })
 
-testthat::test_that("Test second derivative", {
+test_that("Test second derivative", {
 
   # second derivative is a data.frame or is NULL
-  testthat::expect_true(is.data.frame(basic_gam$second_derivative))
-  testthat::expect_true(is.data.frame(basic_gam_ys$second_derivative))
-  testthat::expect_true(is.data.frame(corrected_gam$second_derivative))
-  testthat::expect_true(is.data.frame(corrected_gam_ys$second_derivative))
+  expect_true(is.data.frame(basic_gam$second_derivative))
+  expect_true(is.data.frame(basic_gam_ys$second_derivative))
+  expect_true(is.data.frame(corrected_gam$second_derivative))
+  expect_true(is.data.frame(corrected_gam_ys$second_derivative))
   expect_null(basic_gam_bad$second_derivative)
   expect_null(basic_gam_bad_ys$second_derivative)
   expect_null(corrected_gam_bad$second_derivative)
@@ -692,11 +692,11 @@ testthat::test_that("Test second derivative", {
     "upper_ci",
     "year"
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam$second_derivative,
     has_names(expected = expected_cols_basic)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative,
     has_names(expected = expected_cols_basic)
   )
@@ -710,20 +710,20 @@ testthat::test_that("Test second derivative", {
     "year",
     "baseline_observations"
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative,
     has_names(expected = expected_cols_corrected)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam_ys$second_derivative,
     has_names(expected = expected_cols_corrected)
   )
 
   # smooth column contains only s(year) for basic gam
-  testthat::expect_true(unique(basic_gam$second_derivative$smooth) == "s(year)")
-  testthat::expect_true(unique(basic_gam_ys$second_derivative$smooth) == "s(year)")
-  testthat::expect_false(all(unique(corrected_gam$second_derivative$smooth) == "s(year)"))
-  testthat::expect_false(all(unique(corrected_gam_ys$second_derivative$smooth) == "s(year)"))
+  expect_true(unique(basic_gam$second_derivative$smooth) == "s(year)")
+  expect_true(unique(basic_gam_ys$second_derivative$smooth) == "s(year)")
+  expect_false(all(unique(corrected_gam$second_derivative$smooth) == "s(year)"))
+  expect_false(all(unique(corrected_gam_ys$second_derivative$smooth) == "s(year)"))
 
   # year column and baseline_observations, if present, contain numeric values
   expect_true(is.numeric(basic_gam$second_derivative$year))
@@ -746,95 +746,95 @@ testthat::test_that("Test second derivative", {
   )
 
   # columns derivative, se, crit, lower_ci, upper_ci are numeric
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$derivative))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$se))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$lower_ci))
-  testthat::expect_true(is.numeric(basic_gam$second_derivative$upper_ci))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$derivative))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$se))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$crit))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$lower_ci))
-  testthat::expect_true(is.numeric(basic_gam_ys$second_derivative$upper_ci))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$derivative))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$se))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$lower_ci))
-  testthat::expect_true(is.numeric(corrected_gam$second_derivative$upper_ci))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$derivative))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$se))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$crit))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$lower_ci))
-  testthat::expect_true(is.numeric(corrected_gam_ys$second_derivative$upper_ci))
+  expect_true(is.numeric(basic_gam$second_derivative$derivative))
+  expect_true(is.numeric(basic_gam$second_derivative$se))
+  expect_true(is.numeric(basic_gam$second_derivative$crit))
+  expect_true(is.numeric(basic_gam$second_derivative$lower_ci))
+  expect_true(is.numeric(basic_gam$second_derivative$upper_ci))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$derivative))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$se))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$crit))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$lower_ci))
+  expect_true(is.numeric(basic_gam_ys$second_derivative$upper_ci))
+  expect_true(is.numeric(corrected_gam$second_derivative$derivative))
+  expect_true(is.numeric(corrected_gam$second_derivative$se))
+  expect_true(is.numeric(corrected_gam$second_derivative$crit))
+  expect_true(is.numeric(corrected_gam$second_derivative$lower_ci))
+  expect_true(is.numeric(corrected_gam$second_derivative$upper_ci))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$derivative))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$se))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$crit))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$lower_ci))
+  expect_true(is.numeric(corrected_gam_ys$second_derivative$upper_ci))
 
   # number of evaluation years doesn't affect 2nd derivative values
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative$derivative,
-    testthat::is_identical_to(basic_gam$second_derivative$derivative)
+    is_identical_to(basic_gam$second_derivative$derivative)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative$derivative,
-    testthat::is_identical_to(corrected_gam$second_derivative$derivative)
+    is_identical_to(corrected_gam$second_derivative$derivative)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative$se,
-    testthat::is_identical_to(basic_gam$second_derivative$se)
+    is_identical_to(basic_gam$second_derivative$se)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative$se,
-    testthat::is_identical_to(corrected_gam$second_derivative$se)
+    is_identical_to(corrected_gam$second_derivative$se)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative$crit,
-    testthat::is_identical_to(basic_gam$second_derivative$crit)
+    is_identical_to(basic_gam$second_derivative$crit)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative$crit,
-    testthat::is_identical_to(corrected_gam$second_derivative$crit)
+    is_identical_to(corrected_gam$second_derivative$crit)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative$lower_ci,
-    testthat::is_identical_to(basic_gam$second_derivative$lower_ci)
+    is_identical_to(basic_gam$second_derivative$lower_ci)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative$lower_ci,
-    testthat::is_identical_to(corrected_gam$second_derivative$lower_ci)
+    is_identical_to(corrected_gam$second_derivative$lower_ci)
   )
-  testthat::expect_that(
+  expect_that(
     basic_gam_ys$second_derivative$upper_ci,
-    testthat::is_identical_to(basic_gam$second_derivative$upper_ci)
+    is_identical_to(basic_gam$second_derivative$upper_ci)
   )
-  testthat::expect_that(
+  expect_that(
     corrected_gam$second_derivative$upper_ci,
-    testthat::is_identical_to(corrected_gam$second_derivative$upper_ci)
+    is_identical_to(corrected_gam$second_derivative$upper_ci)
   )
 
   # lower_ci <= derivative <= upper_ci
-  testthat::expect_true(all(basic_gam$second_derivative$lower_ci <=
+  expect_true(all(basic_gam$second_derivative$lower_ci <=
     basic_gam$second_derivative$derivative &
     basic_gam$second_derivative$derivative <=
       basic_gam$second_derivative$upper_ci))
-  testthat::expect_true(all(corrected_gam$second_derivative$lower_ci <=
+  expect_true(all(corrected_gam$second_derivative$lower_ci <=
     corrected_gam$second_derivative$derivative &
     corrected_gam$second_derivative$derivative <=
       corrected_gam$second_derivative$upper_ci))
 })
 
-testthat::test_that("Test plot", {
+test_that("Test plot", {
 
   # plot is always an obejct of class ggplot
-  testthat::expect_true(all(class(basic_gam$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_ys$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(corrected_gam$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(corrected_gam_ys$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_occ$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_taxon_key_as_number$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_taxon_key_as_string$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_taxon_key_and_name$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_bad$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(basic_gam_bad_ys$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(corrected_gam_bad$plot) == c("gg", "ggplot")))
-  testthat::expect_true(all(class(corrected_gam_bad_ys$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_ys$plot) == c("gg", "ggplot")))
+  expect_true(all(class(corrected_gam$plot) == c("gg", "ggplot")))
+  expect_true(all(class(corrected_gam_ys$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_occ$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_taxon_key_as_number$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_taxon_key_as_string$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_taxon_key_and_name$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_bad$plot) == c("gg", "ggplot")))
+  expect_true(all(class(basic_gam_bad_ys$plot) == c("gg", "ggplot")))
+  expect_true(all(class(corrected_gam_bad$plot) == c("gg", "ggplot")))
+  expect_true(all(class(corrected_gam_bad_ys$plot) == c("gg", "ggplot")))
 
   # All plot titles start with "GAM"
   title_plot <- basic_gam_name$plot$labels$title
@@ -852,17 +852,17 @@ testthat::test_that("Test plot", {
     title_plot_with_key_and_name
   )
 
-  testthat::expect_true(all(substr(titles, start = 1, stop = 3) == "GAM"))
+  expect_true(all(substr(titles, start = 1, stop = 3) == "GAM"))
 
   # type of indicator follows the word GAM in title
-  testthat::expect_equal(
+  expect_equal(
     substr(title_plot,
       start = 5,
       stop = 5 + nchar(obs_indicator) - 1
     ),
     obs_indicator
   )
-  testthat::expect_equal(
+  expect_equal(
     substr(title_plot_occ,
       start = 5,
       stop = 5 + nchar(occ_indicator) - 1
@@ -871,7 +871,7 @@ testthat::test_that("Test plot", {
   )
 
   # if provided, value of argument taxon_key is in title of plot
-  testthat::expect_equal(
+  expect_equal(
     substr(
       title_plot_with_key_string,
       start = nchar(title_plot_with_key_string) - nchar(taxon_key) + 1,
@@ -880,7 +880,7 @@ testthat::test_that("Test plot", {
     taxon_key
   )
 
-  testthat::expect_equal(
+  expect_equal(
     substr(
       title_plot_with_key_number,
       start = nchar(title_plot_with_key_number) - nchar(taxon_key) + 1,
@@ -890,11 +890,11 @@ testthat::test_that("Test plot", {
   )
 
   # title of plot doens't change if taxon_key is char or numeric
-  testthat::expect_equal(title_plot_with_key_string, title_plot_with_key_number)
+  expect_equal(title_plot_with_key_string, title_plot_with_key_number)
 
   # if provided, value of argument name is in title of plot at the end
 
-  testthat::expect_equal(
+  expect_equal(
     substr(title_plot_with_name,
       start = nchar(title_plot_with_name) - nchar(name_sp) + 1,
       stop = nchar(title_plot_with_name)
@@ -904,7 +904,7 @@ testthat::test_that("Test plot", {
 
   # if both provided, values of taxon_key and name are in title of plot as
   # taxon_key_name
-  testthat::expect_equal(
+  expect_equal(
     substr(title_plot_with_key_and_name,
       start = nchar(title_plot_with_key_and_name) - nchar(name_sp) - nchar(taxon_key),
       stop = nchar(title_plot_with_key_and_name)
@@ -913,7 +913,7 @@ testthat::test_that("Test plot", {
   )
 })
 
-testthat::test_that("Test warnings and messages.", {
+test_that("Test warnings and messages.", {
   expect_warning(apply_gam(
     df = df_bad,
     y_var = "n_observations",


### PR DESCRIPTION
This PR fixes #113 by adapting `apply_gam()` to the [breaking changes](https://gavinsimpson.github.io/gratia/news/index.html#breaking-changes-0-9-0) in gratia 0.9.0. 

- [x] Adapt function
- [x] Adapt documentation (if needed)
- [x] Update tests
- [x] Minor changes (e.g. tidyselect compliance to avoid deprecation warnings)