### PR TITLE
Add dplyr:: to `distinct()` in `apply_decision_rules()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species
     (TrIAS)
-Version: 2.3.0
+Version: 2.3.1
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/apply_decision_rules.R
+++ b/R/apply_decision_rules.R
@@ -173,7 +173,7 @@ apply_decision_rules <- function(df,
   # Get all taxa in df
   taxon_keys <-
     df %>%
-    distinct(!!rlang::sym(taxonKey)) %>%
+    dplyr::distinct(!!rlang::sym(taxonKey)) %>%
     dplyr::pull()
 
   # Find taxa whose timeseries don't contain eval_year, remove them and throw a
@@ -214,7 +214,7 @@ apply_decision_rules <- function(df,
     dplyr::filter(!!rlang::sym(y_var) > 0) %>%
     dplyr::add_tally(wt = NULL) %>%
     dplyr::mutate(dr_1 = n == 1) %>%
-    distinct(!!rlang::sym(taxonKey), dr_1)
+    dplyr::distinct(!!rlang::sym(taxonKey), dr_1)
 
   # Rule 2: last value (at eval_year) above median value?
   dr_2 <-


### PR DESCRIPTION
In trias indicators we load both tidylog and dplyr. Without the `dplyr::` in that line, R arises an error due to a conflict between the two packages: R doesn't know which `distinct()` function to use. 
In general, this PR has to do with #86.