### PR TITLE
Broken example in `visualize_pathways_year_level2()` + `level1`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,4 @@ Encoding: UTF-8
 LazyData: true
 LazyDataCompression: bzip2
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/apply_decision_rules.R
+++ b/R/apply_decision_rules.R
@@ -300,7 +300,7 @@ apply_decision_rules <- function(df,
 
   em_dr <-
     em_dr %>%
-    bind_rows(taxa_without_em)
+    dplyr::bind_rows(taxa_without_em)
 
   return(em_dr)
 }

--- a/R/apply_decision_rules.R
+++ b/R/apply_decision_rules.R
@@ -54,10 +54,10 @@
 #'   obs = c(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 3, 0)
 #' )
 #' apply_decision_rules(df,
-#'   eval_year = c(2016, 2017, 2018),
+#'   eval_year = 2016,
 #'   y_var = "obs",
 #'   taxonKey = "taxonID",
-#'   year = y
+#'   year = "y"
 #' )
 #' }
 #'

--- a/R/apply_decision_rules.R
+++ b/R/apply_decision_rules.R
@@ -47,7 +47,6 @@
 #' - (`dr_1` is `TRUE`  and `dr_3` is `FALSE`) or (`dr_1`, `dr_2` and `dr_3` are
 #' `FALSE`): `em = 1` (unclear)
 #' @examples
-#' \dontrun{
 #' df <- dplyr::tibble(
 #'   taxonID = c(rep(1008955, 10), rep(2493598, 3)),
 #'   y = c(seq(2009, 2018), seq(2016, 2018)),
@@ -59,8 +58,6 @@
 #'   taxonKey = "taxonID",
 #'   year = "y"
 #' )
-#' }
-#'
 apply_decision_rules <- function(df,
                                  y_var = "ncells",
                                  eval_year,

--- a/R/data-legends.R
+++ b/R/data-legends.R
@@ -6,10 +6,10 @@
 #'   
 #'   Each data.frame contains two columns: 
 #'   - `GRIDCODE`: (numeric) grid value corresponding to a climate zone 
-#'   - `Classification`: (character) Koppen-{G}eiger climate classification value
-#'   - `Description`: (character) verbose description of the Koppen-{G}eiger
+#'   - `Classification`: (character) Koppen-Geiger climate classification value
+#'   - `Description`: (character) verbose description of the Koppen-Geiger
 #'   climate zone, e.g. "Tropical rainforest climate"
-#'   - `Group`: (character) group the Koppen-{G}eiger climate zone belongs to,
+#'   - `Group`: (character) group the Koppen-Geiger climate zone belongs to,
 #'   e.g. "Tropical"
 #'   - `Precipitation Type`: (character) Type of precipitations associated to
 #'   the climate zone, e.g. "Rainforest"

--- a/R/gbif_verify_keys.R
+++ b/R/gbif_verify_keys.R
@@ -34,6 +34,7 @@
 #' @importFrom dplyr .data %>%
 #' @importFrom rlang !!
 #' @examples
+#' \dontrun{
 #' # input is a vector
 #' keys1 <- c(
 #'   "12323785387253", # invalid GBIF taxonKey
@@ -64,6 +65,7 @@
 #' gbif_verify_keys(keys2, col_keys = "keys")
 #' gbif_verify_keys(keys3)
 #' gbif_verify_keys(keys4)
+#' }
 gbif_verify_keys <- function(keys, col_keys = "key") {
   assertthat::assert_that(is.data.frame(keys) | is.vector(keys),
     msg = "keys should be a vector, a named list or a data.frame."

--- a/R/gbif_verify_keys.R
+++ b/R/gbif_verify_keys.R
@@ -1,35 +1,32 @@
 #' Check keys against GBIF Backbone Taxonomy
 #'
 #' This function performs three checks:
-#' \itemize{
-#'   \item{\code{keys} are valid GBIF taxon keys. That means that adding a key
+#' - `keys` are valid GBIF taxon keys. That means that adding a key
 #'   at the end of the URL https://www.gbif.org/species/ returns a GBIF page
-#'   related to a taxa.}
-#'   \item{\code{keys} are taxon keys of the GBIF Backbone Taxonomy checklist.
+#'   related to a taxa.
+#' - `keys` are taxon keys of the GBIF Backbone Taxonomy checklist.
 #'   That means that adding a key at the end of the URL
 #'   https://www.gbif.org/species/ returns a GBIF page related to a taxa of the
-#'   GBIF Backbone.)}
-#'   \item{\code{keys} are synonyms of other taxa (taxonomicStatus neither
-#'   \code{ACCEPTED} nor \code{DOUBTFUL}).}
-#'   }.
+#'   GBIF Backbone.)
+#' - `keys` are synonyms of other taxa (taxonomicStatus neither
+#'   `ACCEPTED` nor `DOUBTFUL`).
 #' @param keys (character or numeric) a vector, a list, or a data.frame
 #'   containing the keys to verify.
 #' @param col_keys (character) name of column containing keys in case
-#'   \code{keys} is a data.frame.
+#'   `keys` is a data.frame.
 #'
 #' @return a data.frame with the following columns:
-#'   \itemize{
-#'     \item{\code{key}}{:(numeric) keys as input keys.}
-#'     \item{\code{is_taxonKey}} {: (logical) is the key a valid GBIF taxon
-#'     key?}
-#'   \item{\code{is_from_gbif_backbone}} {:(logical) is the key a valid taxon
-#'   key from GBIF Backbone Taxonomy checklist?}
-#'   \item{\code{is_synonym}} {: (logical) is the key related to a synonym (not
-#'   \code{ACCEPTED} or \code{DOUBTFUL})?}
-#'   }
-#'   If a key didn't pass the first check (\code{is_taxonKey = FALSE}) then
-#'   \code{NA} for other two columns. If a key didn't pass the second check
-#'   (\code{is_from_gbif_backbone = FALSE}) then \code{is_synonym} = \code{NA}.
+#' - `key`: (numeric) keys as input keys.
+#' - `is_taxonKey`: (logical) is the key a valid GBIF taxon key?
+#' - `is_from_gbif_backbone`: (logical) is the key a valid taxon key from 
+#' GBIF Backbone Taxonomy checklist?
+#' - `is_synonym`: (logical) is the key related to a synonym (not
+#'   `ACCEPTED` or `DOUBTFUL`)?
+#'   
+#' If a key didn't pass the first check (`is_taxonKey` = `FALSE`) then
+#' `NA` for other two columns. If a key didn't pass the second check
+#' (`is_from_gbif_backbone` = `FALSE`) then `is_synonym` = `NA`.
+#' 
 #' @export
 #' @importFrom dplyr .data %>%
 #' @importFrom rlang !!
@@ -51,7 +48,6 @@
 #' )
 #' # input is a named list
 #' keys3 <- keys1
-#' library(purrr)
 #' names(keys3) <- purrr::map_chr(
 #'   c(1:length(keys3)),
 #'   ~ paste(sample(c(0:9, letters, LETTERS), 3),

--- a/R/indicator_native_range_year.R
+++ b/R/indicator_native_range_year.R
@@ -5,7 +5,7 @@
 #' [countYearProvince](https://github.com/inbo/reporting-rshiny-grofwildjacht/blob/exoten/reporting-grofwild/R/countYearProvince.R)
 #' plot from reporting - rshiny - grofwildjacht
 #' @param df input data.frame.
-#' @param years (numeric) vector years we are interested to. If \code{NULL}
+#' @param years (numeric) vector years we are interested to. If `NULL`
 #'   (default) all years from minimum and maximum of years of first observation
 #'   are taken into account.
 #' @param type character, native_range level of interest should be one of
@@ -16,22 +16,26 @@
 #'   species".
 #' @param relative (logical) if TRUE (default), each bar is standardised before
 #'   stacking.
-#' @param taxon_key_col character. Name of the column of \code{df} containing
-#'   taxon IDs. Default: \code{"key"}.
+#' @param taxon_key_col character. Name of the column of `df` containing
+#'   taxon IDs. Default: `"key"`.
 #' @param first_observed (character) Name of the column in `data`
 #'   containing temporal information about introduction of the alien species.
 #'   Expressed as years.
-#' @return list with: \itemize{ \item{'static_plot': }{ggplot object, for a
+#' @return list with:
+#' - `static_plot`: ggplot object, for a
 #'   given species the observed number per year and per native range is plotted
-#'   in a stacked bar chart} \item{'interactive_plot': }{plotly object, for a
+#'   in a stacked bar chart.
+#' - `interactive_plot`: plotly object, for a
 #'   given species the observed number per year and per native range is plotted
-#'   in a stacked bar chart} \item{'data': }{data displayed in the plot, as
-#'   data.frame with: \itemize{ \item{'year': }{year at which the species were
-#'   introduced} \item{'native_range': }{native range of the introduced species}
-#'   \item{'n': }{number of species introduced from the native range for a given
-#'   year} \item{'total': }{total number of species, from all around the world,
-#'   introduced during a given year} \item{'perc': }{percentage of species
-#'   introduced from the native range for a given year. (n/total)*100} } } }
+#'   in a stacked bar chart.
+#' - `data`: data displayed in the plot, as a data.frame with: 
+#'   - `year`: year at which the species were introduced.
+#'   - `native_range`: native range of the introduced species.
+#'   - `n`: number of species introduced from the native range for a given year.
+#'   - `total`: total number of species, from all around the world, introduced.
+#'   during a given year.
+#'   - `perc`: percentage of species introduced from the native range for a 
+#'   given year, `n`/`total`*100.
 #' @export
 #' @importFrom dplyr %>% .data
 #' @examples

--- a/R/verify_taxa.R
+++ b/R/verify_taxa.R
@@ -1212,7 +1212,7 @@ verify_taxa <- function(taxa,
         .data$bb_scientificName,
         .data$n
       ) %>%
-      dplyr::arrange(dply::desc(.data$n)) %>%
+      dplyr::arrange(dplyr::desc(.data$n)) %>%
       dplyr::ungroup()
   } else {
     duplicates <- dplyr::tibble(

--- a/R/verify_taxa.R
+++ b/R/verify_taxa.R
@@ -1237,7 +1237,7 @@ verify_taxa <- function(taxa,
   # Order verification by outdated and dateAdded
   verification <-
     verification %>%
-    dplyr::arrange(.data$outdated, dply::desc(.data$dateAdded))
+    dplyr::arrange(.data$outdated, dplyr::desc(.data$dateAdded))
   
   # Add not outdated taxa from verification to not_to_verify_taxa
   taxa <-

--- a/R/verify_taxa.R
+++ b/R/verify_taxa.R
@@ -666,12 +666,12 @@ verify_taxa <- function(taxa,
   assertthat::assert_that(
     taxa %>%
       dplyr::filter(is.na(.data$bb_key)) %>%
-      dplyr::filter_at(dplyr::vars(starts_with("bb_")),
+      dplyr::filter_at(dplyr::vars(dplyr::starts_with("bb_")),
                        dplyr::all_vars(is.na(.))) %>%
       nrow() ==
       taxa %>%
       dplyr::filter(is.na(.data$bb_key)) %>%
-      dplyr::filter_at(dplyr::vars(starts_with("bb_")),
+      dplyr::filter_at(dplyr::vars(dplyr::starts_with("bb_")),
                        dplyr::any_vars(is.na(.))) %>%
       nrow(),
     msg = "Columns with GBIF Backbone info should be empty for unmatched taxa."
@@ -1212,7 +1212,7 @@ verify_taxa <- function(taxa,
         .data$bb_scientificName,
         .data$n
       ) %>%
-      dplyr::arrange(desc(.data$n)) %>%
+      dplyr::arrange(dply::desc(.data$n)) %>%
       dplyr::ungroup()
   } else {
     duplicates <- dplyr::tibble(
@@ -1237,7 +1237,7 @@ verify_taxa <- function(taxa,
   # Order verification by outdated and dateAdded
   verification <-
     verification %>%
-    dplyr::arrange(.data$outdated, desc(.data$dateAdded))
+    dplyr::arrange(.data$outdated, dply::desc(.data$dateAdded))
   
   # Add not outdated taxa from verification to not_to_verify_taxa
   taxa <-

--- a/R/visualize_pathways_level1.R
+++ b/R/visualize_pathways_level1.R
@@ -262,10 +262,14 @@ visualize_pathways_level1 <- function(df,
   # rename to default column name
   df <-
     df %>%
-    dplyr::rename_at(vars(tidyselect::all_of(kingdom_names)), ~"group") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(taxon_names)), ~"taxonKey") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(first_observed)), ~"first_observed") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level1_names)), ~"pathway_level1")
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(kingdom_names)),
+                     ~"group") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(taxon_names)),
+                     ~"taxonKey") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(first_observed)),
+                     ~"first_observed") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(pathway_level1_names)),
+                     ~"pathway_level1")
   # handle asymmetric category system (Chordata, Not Chordta are not kingdoms)
   if (!is.null(category)) {
     if (!category %in% c("Chordata", "Not Chordata")) {
@@ -273,7 +277,7 @@ visualize_pathways_level1 <- function(df,
     } else {
       df <-
         df %>%
-        dplyr::rename_at(vars(phylum_names), ~"phylum_group")
+        dplyr::rename_at(dplyr::vars(phylum_names), ~"phylum_group")
       if (category == "Chordata") {
         df <- df %>% dplyr::filter(.data$phylum_group == category)
       } else {

--- a/R/visualize_pathways_level2.R
+++ b/R/visualize_pathways_level2.R
@@ -327,11 +327,16 @@ visualize_pathways_level2 <- function(df,
   # rename to default column name
   df <-
     df %>%
-    dplyr::rename_at(vars(tidyselect::all_of(kingdom_names)), ~"group") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(taxon_names)), ~"taxonKey") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(first_observed)), ~"first_observed") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level1_names)), ~"pathway_level1") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level2_names)), ~"pathway_level2")
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(kingdom_names)),
+                     ~"group") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(taxon_names)),
+                     ~"taxonKey") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(first_observed)),
+                     ~"first_observed") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(pathway_level1_names)),
+                     ~"pathway_level1") %>%
+    dplyr::rename_at(dplyr::vars(tidyselect::all_of(pathway_level2_names)),
+                     ~"pathway_level2")
   # Select data with the chosen pathway level 1
   df <-
     df %>%
@@ -343,7 +348,7 @@ visualize_pathways_level2 <- function(df,
     } else {
       df <-
         df %>%
-        dplyr::rename_at(vars(phylum_names), ~"phylum_group")
+        dplyr::rename_at(dplyr::vars(phylum_names), ~"phylum_group")
       if (category == "Chordata") {
         df <- df %>% dplyr::filter(.data$phylum_group == category)
       } else {

--- a/R/visualize_pathways_year_level1.R
+++ b/R/visualize_pathways_year_level1.R
@@ -287,8 +287,10 @@ visualize_pathways_year_level1 <- function(
     df %>%
     dplyr::rename_at(dplyr::vars(dplyr::all_of(kingdom_names)), ~"group") %>%
     dplyr::rename_at(dplyr::vars(dplyr::all_of(taxon_names)), ~"taxonKey") %>%
-    dplyr::rename_at(dplyr::vars(dplyr::all_of(first_observed)), ~"first_observed") %>%
-    dplyr::rename_at(dplyr::vars(dplyr::all_of(pathway_level1_names)), ~"pathway_level1")
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(first_observed)),
+                     ~"first_observed") %>%
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(pathway_level1_names)),
+                     ~"pathway_level1")
   
   # handle asymmetric category system (Chordata, Not Chordata are not kingdoms)
   if (!is.null(category)) {
@@ -297,7 +299,7 @@ visualize_pathways_year_level1 <- function(
     } else {
       df <-
         df %>%
-        dplyr::rename_at(vars(phylum_names), ~"phylum_group")
+        dplyr::rename_at(dplyr::vars(phylum_names), ~"phylum_group")
       if (category == "Chordata") {
         df <- df %>% dplyr::filter(.data$phylum_group == category)
       } else {

--- a/R/visualize_pathways_year_level1.R
+++ b/R/visualize_pathways_year_level1.R
@@ -285,10 +285,10 @@ visualize_pathways_year_level1 <- function(
   # rename to default column name
   df <-
     df %>%
-    dplyr::rename_at(vars(tidyselect::all_of(kingdom_names)), ~"group") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(taxon_names)), ~"taxonKey") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(first_observed)), ~"first_observed") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level1_names)), ~"pathway_level1")
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(kingdom_names)), ~"group") %>%
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(taxon_names)), ~"taxonKey") %>%
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(first_observed)), ~"first_observed") %>%
+    dplyr::rename_at(dplyr::vars(dplyr::all_of(pathway_level1_names)), ~"pathway_level1")
   
   # handle asymmetric category system (Chordata, Not Chordata are not kingdoms)
   if (!is.null(category)) {

--- a/R/visualize_pathways_year_level2.R
+++ b/R/visualize_pathways_year_level2.R
@@ -341,11 +341,16 @@ visualize_pathways_year_level2 <- function(
   # rename to default column name
   df <-
     df %>%
-    dplyr::rename_at(vars(tidyselect::all_of(kingdom_names)), ~"group") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(taxon_names)), ~"taxonKey") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(first_observed)), ~"first_observed") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level1_names)), ~"pathway_level1") %>%
-    dplyr::rename_at(vars(tidyselect::all_of(pathway_level2_names)), ~"pathway_level2")
+    dplyr::rename_at(
+      dplyr::vars(dplyr::all_of(kingdom_names)), ~"group") %>%
+    dplyr::rename_at(
+      dplyr::vars(dplyr::all_of(taxon_names)), ~"taxonKey") %>%
+    dplyr::rename_at(
+      dplyr::vars(dplyr::all_of(first_observed)), ~"first_observed") %>%
+    dplyr::rename_at(
+      dplyr::vars(dplyr::all_of(pathway_level1_names)), ~"pathway_level1") %>%
+    dplyr::rename_at(
+      dplyr::vars(dplyr::all_of(pathway_level2_names)), ~"pathway_level2")
   # Select data with the chosen pathway level 1
   df <-
     df %>%

--- a/R/visualize_pathways_year_level2.R
+++ b/R/visualize_pathways_year_level2.R
@@ -362,7 +362,7 @@ visualize_pathways_year_level2 <- function(
     } else {
       df <-
         df %>%
-        dplyr::rename_at(vars(phylum_names), ~"phylum_group")
+        dplyr::rename_at(dplyr::vars(phylum_names), ~"phylum_group")
       if (category == "Chordata") {
         df <- df %>% dplyr::filter(.data$phylum_group == category)
       } else {

--- a/man/apply_decision_rules.Rd
+++ b/man/apply_decision_rules.Rd
@@ -67,18 +67,15 @@ Based on the decision rules output we define the emergency status value,
 }
 }
 \examples{
-\dontrun{
 df <- dplyr::tibble(
   taxonID = c(rep(1008955, 10), rep(2493598, 3)),
   y = c(seq(2009, 2018), seq(2016, 2018)),
   obs = c(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 3, 0)
 )
 apply_decision_rules(df,
-  eval_year = c(2016, 2017, 2018),
+  eval_year = 2016,
   y_var = "obs",
   taxonKey = "taxonID",
-  year = y
+  year = "y"
 )
-}
-
 }

--- a/man/gbif_verify_keys.Rd
+++ b/man/gbif_verify_keys.Rd
@@ -16,33 +16,34 @@ containing the keys to verify.}
 \value{
 a data.frame with the following columns:
 \itemize{
-\item{\code{key}}{:(numeric) keys as input keys.}
-\item{\code{is_taxonKey}} {: (logical) is the key a valid GBIF taxon
-key?}
-\item{\code{is_from_gbif_backbone}} {:(logical) is the key a valid taxon
-key from GBIF Backbone Taxonomy checklist?}
-\item{\code{is_synonym}} {: (logical) is the key related to a synonym (not
-\code{ACCEPTED} or \code{DOUBTFUL})?}
+\item \code{key}: (numeric) keys as input keys.
+\item \code{is_taxonKey}: (logical) is the key a valid GBIF taxon key?
+\item \code{is_from_gbif_backbone}: (logical) is the key a valid taxon key from
+GBIF Backbone Taxonomy checklist?
+\item \code{is_synonym}: (logical) is the key related to a synonym (not
+\code{ACCEPTED} or \code{DOUBTFUL})?
 }
-If a key didn't pass the first check (\code{is_taxonKey = FALSE}) then
+
+If a key didn't pass the first check (\code{is_taxonKey} = \code{FALSE}) then
 \code{NA} for other two columns. If a key didn't pass the second check
-(\code{is_from_gbif_backbone = FALSE}) then \code{is_synonym} = \code{NA}.
+(\code{is_from_gbif_backbone} = \code{FALSE}) then \code{is_synonym} = \code{NA}.
 }
 \description{
 This function performs three checks:
 \itemize{
-\item{\code{keys} are valid GBIF taxon keys. That means that adding a key
+\item \code{keys} are valid GBIF taxon keys. That means that adding a key
 at the end of the URL https://www.gbif.org/species/ returns a GBIF page
-related to a taxa.}
-\item{\code{keys} are taxon keys of the GBIF Backbone Taxonomy checklist.
+related to a taxa.
+\item \code{keys} are taxon keys of the GBIF Backbone Taxonomy checklist.
 That means that adding a key at the end of the URL
 https://www.gbif.org/species/ returns a GBIF page related to a taxa of the
-GBIF Backbone.)}
-\item{\code{keys} are synonyms of other taxa (taxonomicStatus neither
-\code{ACCEPTED} nor \code{DOUBTFUL}).}
-}.
+GBIF Backbone.)
+\item \code{keys} are synonyms of other taxa (taxonomicStatus neither
+\code{ACCEPTED} nor \code{DOUBTFUL}).
+}
 }
 \examples{
+\dontrun{
 # input is a vector
 keys1 <- c(
   "12323785387253", # invalid GBIF taxonKey
@@ -59,7 +60,6 @@ keys2 <- data.frame(
 )
 # input is a named list
 keys3 <- keys1
-library(purrr)
 names(keys3) <- purrr::map_chr(
   c(1:length(keys3)),
   ~ paste(sample(c(0:9, letters, LETTERS), 3),
@@ -73,4 +73,5 @@ gbif_verify_keys(keys1)
 gbif_verify_keys(keys2, col_keys = "keys")
 gbif_verify_keys(keys3)
 gbif_verify_keys(keys4)
+}
 }

--- a/man/indicator_native_range_year.Rd
+++ b/man/indicator_native_range_year.Rd
@@ -43,17 +43,25 @@ containing temporal information about introduction of the alien species.
 Expressed as years.}
 }
 \value{
-list with: \itemize{ \item{'static_plot': }{ggplot object, for a
+list with:
+\itemize{
+\item \code{static_plot}: ggplot object, for a
 given species the observed number per year and per native range is plotted
-in a stacked bar chart} \item{'interactive_plot': }{plotly object, for a
+in a stacked bar chart.
+\item \code{interactive_plot}: plotly object, for a
 given species the observed number per year and per native range is plotted
-in a stacked bar chart} \item{'data': }{data displayed in the plot, as
-data.frame with: \itemize{ \item{'year': }{year at which the species were
-introduced} \item{'native_range': }{native range of the introduced species}
-\item{'n': }{number of species introduced from the native range for a given
-year} \item{'total': }{total number of species, from all around the world,
-introduced during a given year} \item{'perc': }{percentage of species
-introduced from the native range for a given year. (n/total)*100} } } }
+in a stacked bar chart.
+\item \code{data}: data displayed in the plot, as a data.frame with:
+\itemize{
+\item \code{year}: year at which the species were introduced.
+\item \code{native_range}: native range of the introduced species.
+\item \code{n}: number of species introduced from the native range for a given year.
+\item \code{total}: total number of species, from all around the world, introduced.
+during a given year.
+\item \code{perc}: percentage of species introduced from the native range for a
+given year, \code{n}/\code{total}*100.
+}
+}
 }
 \description{
 Based on

--- a/man/legends.Rd
+++ b/man/legends.Rd
@@ -12,10 +12,10 @@ respectively.
 Each data.frame contains two columns:
 \itemize{
 \item \code{GRIDCODE}: (numeric) grid value corresponding to a climate zone
-\item \code{Classification}: (character) Koppen-{G}eiger climate classification value
-\item \code{Description}: (character) verbose description of the Koppen-{G}eiger
+\item \code{Classification}: (character) Koppen-Geiger climate classification value
+\item \code{Description}: (character) verbose description of the Koppen-Geiger
 climate zone, e.g. "Tropical rainforest climate"
-\item \code{Group}: (character) group the Koppen-{G}eiger climate zone belongs to,
+\item \code{Group}: (character) group the Koppen-Geiger climate zone belongs to,
 e.g. "Tropical"
 \item \verb{Precipitation Type}: (character) Type of precipitations associated to
 the climate zone, e.g. "Rainforest"

--- a/tests/testthat/test-visualize_pathways_year_level1.R
+++ b/tests/testthat/test-visualize_pathways_year_level1.R
@@ -16,8 +16,8 @@ n_first_observed_na <-
 
 valid_pathways <-
   pathways_cbd() %>%
-  distinct(pathway_level1) %>%
-  pull()
+  dplyr::distinct(pathway_level1) %>%
+  dplyr::pull()
 
 invalid_pathways_df <- input_test_df[1:6, ]
 

--- a/tests/testthat/test-visualize_pathways_year_level2.R
+++ b/tests/testthat/test-visualize_pathways_year_level2.R
@@ -22,7 +22,7 @@ input_test_df <-
 
 input_test_df_other_colnames <-
   input_test_df %>%
-  rename(
+  dplyr::rename(
     date_introduction = first_observed,
     pathway_1 = pathway_level1,
     pathway_2 = pathway_level2,
@@ -32,9 +32,9 @@ input_test_df_other_colnames <-
 
 valid_pathways_escape <-
   pathways_cbd() %>%
-  filter(pathway_level1 == "escape") %>%
-  distinct(pathway_level2) %>%
-  pull()
+  dplyr::filter(pathway_level1 == "escape") %>%
+  dplyr::distinct(pathway_level2) %>%
+  dplyr::pull()
 
 invalid_pathways_df <- input_test_df[1:6, ]
 invalid_pathways_df$pathway_level1 <- rep("escape", 6)


### PR DESCRIPTION
During review I noticed that an example in `visualize_pathways_year_level2()` wouldn't work unless `dplyr` was already loaded. I added some extra namespace calls to dplyr. 

Then, when running the unit tests, these failed because they were using dplyr functions that are not in the `NAMESPACE` without the `dplyr::` in front of them. 

I also switched out some calls to `tidyselect` to `dplyr` because this was shorter and this might help removing a direct dependency on `tidyselect`, altough you'll still be indirectly dependent on it though `dplyr` of course. I'm not sure if this causes the package to need a certain minimum version of `dplyr`. 

EDIT: just saw the same for `visualize_pathways_year_level1()`