### PR TITLE
Add ROR for INBO, add DOI for b-cubed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,14 +19,14 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-6658-6062")),
     person("Machteld", "Varewyck", , "machteld.varewyck@openanalytics.eu", role = "aut",
            comment = c(ORCID = "0009-0003-0496-0447")),
-    person("Research Institute for Nature and Forest (INBO)", role = c("cph", "fnd"), email = "info@inbo.be",
-           comment = "https://www.vlaanderen.be/inbo/en-gb/"),
+    person("Research Institute for Nature and Forest (INBO)", role = ("cph", "fnd"),
+           comment = c(ROR = "00j54wy13")),
     person("TrIAS", role = "fnd",
            comment = "https://trias-project.be"),
     person("LIFE RIPARIAS", role = "fnd",
            comment = "https://www.riparias.be"),
-    person("B-Cubed (Horizon Europe ID No 101059592)", role = "fnd",
-           comment = "https://b-cubed.eu/")
+    person("European Union", role = "fnd",
+           comment = "https://doi.org/10.3030/101059592")
   )
 Description: This package provides functionality to facilitate the data
     processing for the project Tracking Invasive Alien Species (TrIAS


### PR DESCRIPTION
[pkgdown 2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now supports ROR Identifiers for organizations. Since this supports better linked data, I think we should adopt it for our packages.

It will display on the pkgdown website as:

<img width="585" alt="Screenshot 2025-04-28 at 15 13 10" src="https://github.com/user-attachments/assets/3b4f44a8-760a-4316-9d37-9813b3792fa5" />

It might take a bit until GitHub Actions use pkgdown 2.1.2, so it will currently display as:

<img width="539" alt="Screenshot 2025-04-28 at 15 13 23" src="https://github.com/user-attachments/assets/13544ffe-b62a-4392-a99d-a82a9b8048a8" />

Eventually, this will resolve itself on future builds.

I've also linked our B-Cubed funder to the official DOI.