### PR TITLE
Solve bug 166

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species
     (TrIAS)
-Version: 3.1.0
+Version: 3.1.1
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# trias 3.1.1
+
+- Fix a bug in `indicator_native_range_year()` when `response_type = "cumulative"` and `x_include_missing = TRUE` (#166). Unit-tests for `indicator_native_range_year()` are also extended.
+- Add some more examples in documentation of `indicator_native_range_year()`.
+
 # trias 3.1.0
 
 - Improve `indicator_native_range_year()`: Add option `x_include_missing` for including missing years as gaps on x-axis in the plot (#163).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fix a bug in `indicator_native_range_year()` when `response_type = "cumulative"` and `x_include_missing = TRUE` (#166). Unit-tests for `indicator_native_range_year()` are also extended.
 - Add some more examples in documentation of `indicator_native_range_year()`.
+- - Improved the logic for determining x-axis scale steps to better handle cases with a small range of years.
 
 # trias 3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 - Fix a bug in `indicator_native_range_year()` when `response_type = "cumulative"` and `x_include_missing = TRUE` (#166). Unit-tests for `indicator_native_range_year()` are also extended.
 - Add some more examples in documentation of `indicator_native_range_year()`.
-- - Improved the logic for determining x-axis scale steps to better handle cases with a small range of years.
+- Improved the logic for determining x-axis scale steps to better handle cases with a small range of years.
+- Fix `gbif_verify_keys()` and its tests. It appeared a strange anomaly while checking if a key is a valid taxon key. Also, made use for the first time of the rgbif patch (#805) to avoid GBIF API issues for Windows users (#165).
 
 # trias 3.1.0
 

--- a/R/gbif_verify_keys.R
+++ b/R/gbif_verify_keys.R
@@ -35,7 +35,7 @@
 #' # input is a vector
 #' keys1 <- c(
 #'   "12323785387253", # invalid GBIF taxonKey
-#'   "128545334", # valid taxonKey, not a GBIF Backbone key
+#'   "194877248", # valid taxonKey, not a GBIF Backbone key
 #'   "1000693", # a GBIF Backbone key, synonym
 #'   "1000310", # a GBIF Backbone key, accepted
 #'   NA, NA
@@ -109,13 +109,14 @@ gbif_verify_keys <- function(keys, col_keys = "key") {
   names(keys) <- as.character(keys)
   gbif_info <-
     keys %>%
-    purrr::map(~ tryCatch(rgbif::name_usage(.)$data[1, ],
+    purrr::map(~ tryCatch(
+      rgbif::name_usage(., curlopts=list(http_version = 2))$data[1, ],
       error = function(e) {
-        print(paste("Key", ., "is an invalid GBIF taxon key."))
+        message(paste("Key", ., "is an invalid GBIF taxon key."))
       }
-    ))
+  ))
   check_keys <-
-    purrr::map_df(gbif_info, ~ is.character(.) == FALSE)
+    purrr::map_df(gbif_info, ~ is.null(.) == FALSE)
   check_keys <-
     check_keys %>%
     tidyr::gather(key = "key", value = "is_taxonKey") %>%

--- a/R/indicator_introduction_year.R
+++ b/R/indicator_introduction_year.R
@@ -1,32 +1,3 @@
-#' Generate nice sequence with slightly different cut values compared to \code{\link[base]{seq}}
-#' 
-#' The inner values are forced to be a multiple of the stepsize
-#' 
-#' @param start_year (integer) The min cut value.
-#' @param end_year (integer) The max cut value.
-#' @param step_size (integer) The max distance between two cut values.
-#' 
-#' @return (integer vector) All cut values.
-#' 
-#' @noRd
-nice_seq <- function(start_year, end_year, step_size) {
-  
-  # Calculate the first "nice" cut point (round up to the nearest multiple of step_size)
-  first_nice_cut <- ceiling(start_year / step_size) * step_size
-  nice_cuts <- seq(from = first_nice_cut, to = end_year, by = step_size)
-  
-  cuts <- c(
-    start_year, 
-    nice_cuts,
-    if (end_year > utils::tail(nice_cuts, n = 1)) end_year 
-  )
-  
-  return(cuts)
-  
-}
-
-
-
 #' Plot number of new introductions per year.
 #'
 #' @description Calculate how many new species has been introduced in a year.

--- a/R/indicator_native_range_year.R
+++ b/R/indicator_native_range_year.R
@@ -86,7 +86,7 @@
 #' indicator_native_range_year(
 #'   data,
 #'   response_type = "cumulative",
-#'   x_include_missing = TRUE,
+#'   x_include_missing = TRUE
 #' )
 #' }
 indicator_native_range_year <- function(

--- a/R/indicator_native_range_year.R
+++ b/R/indicator_native_range_year.R
@@ -85,7 +85,7 @@
 #' # Include missing years on the x-axis
 #' indicator_native_range_year(
 #'   data,
-#'   response_type = "cumulative"
+#'   response_type = "cumulative",
 #'   x_include_missing = TRUE,
 #' )
 #' }

--- a/R/indicator_native_range_year.R
+++ b/R/indicator_native_range_year.R
@@ -26,8 +26,9 @@
 #'   Default: `"absolute"`. If "absolute" the number per year and location
 #' is displayed; if "relative" each bar is standardised per year before stacking;
 #' if "cumulative" the cumulative number over years per location.
-#' @param relative (logical) if `TRUE` each bar is standardised before
-#'   stacking. Deprecated, use `response_type = "relative"` instead.
+#' @param relative `r lifecycle::badge("deprecated")` (logical) If `TRUE` each
+#'   bar is standardised before stacking. Deprecated, use `response_type =
+#'   "relative"` instead.
 #' @param taxon_key_col character. Name of the column of `df` containing
 #'   taxon IDs. Default: `"key"`.
 #' @param first_observed (character) Name of the column in `data`
@@ -67,8 +68,26 @@
 #'     first_observed = col_double(),
 #'     last_observed = col_double()
 #'   )
+#' ) 
+#' data <- data[data$locality == "Belgium", ]
+#' 
+#' # Specify the type of native range we are interested in
+#' indicator_native_range_year(data, type = "native_continent")
+#' 
+#' # Specify the years we are interested in
+#' indicator_native_range_year(data, years = 2010:2013)
+#' indicator_native_range_year(data, years = c(2010, 2013))
+#' 
+#' # Specify the response type
+#' indicator_native_range_year(data, response_type = "relative")
+#' indicator_native_range_year(data, response_type = "cumulative")
+#' 
+#' # Include missing years on the x-axis
+#' indicator_native_range_year(
+#'   data,
+#'   response_type = "cumulative"
+#'   x_include_missing = TRUE,
 #' )
-#' indicator_native_range_year(data, "native_continent", years = c(2010,2013))
 #' }
 indicator_native_range_year <- function(
     df,
@@ -82,7 +101,7 @@ indicator_native_range_year <- function(
     relative = lifecycle::deprecated(),
     taxon_key_col = "key",
     first_observed = "first_observed") {
-    
+  
   
   # initial input checks
   assertthat::assert_that(is.data.frame(df))
@@ -102,10 +121,10 @@ indicator_native_range_year <- function(
                           msg = sprintf("Column %s not present in df.", type)
   )
   assertthat::assert_that(is.numeric(x_major_scale_stepsize),
-    msg = "Argument x_major_scale_stepsize has to be a number."
+                          msg = "Argument x_major_scale_stepsize has to be a number."
   )
   assertthat::assert_that(is.logical(x_include_missing),
-    msg = "Argument x_include_missing has to be a logical."
+                          msg = "Argument x_include_missing has to be a logical."
   )
   if (!is.null(x_lab)) {
     assertthat::assert_that(is.character(x_lab),
@@ -134,7 +153,7 @@ indicator_native_range_year <- function(
   }
   
   assertthat::assert_that(is.character(taxon_key_col),
-    msg = "Argument taxon_key_col has to be a character."
+                          msg = "Argument taxon_key_col has to be a character."
   )
   assertable::assert_colnames(df, taxon_key_col, only_colnames = FALSE)
   assertthat::assert_that(is.character(first_observed),
@@ -149,81 +168,98 @@ indicator_native_range_year <- function(
     dplyr::rename_at(dplyr::vars(dplyr::all_of(first_observed)), ~"first_observed") %>%
     dplyr::rename_at(dplyr::vars(dplyr::all_of(taxon_key_col)), ~"key")
   
-  if (is.null(years)) {
-    years <- sort(unique(df$first_observed))
-  }
-
   plotData <- df
-
   plotData$location <- switch(type,
-    native_range = plotData$native_range,
-    native_continent = plotData$native_continent
+                              native_range = plotData$native_range,
+                              native_continent = plotData$native_continent
   )
-
+  
   # Select data
-  plotData <- plotData[!duplicated(plotData[, c("key", "first_observed", "location")]), ]
-  plotData <- plotData[plotData$first_observed %in% years, c("first_observed", "location")]
-  plotData <- plotData[!is.na(plotData$first_observed) & !is.na(plotData$location), ]
+  plotData <- plotData[
+    !duplicated(plotData[, c("key", "first_observed", "location")]),
+  ]
+  # Remove rows with NA in first_observed or location
+  plotData <- plotData[
+    !is.na(plotData$first_observed) & !is.na(plotData$location),
+  ]
+  if (is.null(years)) {
+    years <- sort(unique(plotData$first_observed))
+  }
+  plotData <- plotData[
+    plotData$first_observed %in% years, c("first_observed", "location")
+  ]
   
   # Set location and first_observed to factors
   plotData$first_observed <- as.factor(plotData$first_observed)
   plotData$location <- as.factor(plotData$location)
   plotData$location <- droplevels(plotData$location)
   
-  
   # Summarize data per native_range and year
   summaryData <- reshape2::melt(table(plotData), id.vars = "first_observed")
   summaryData <- summaryData %>%
     dplyr::group_by(.data$first_observed) %>%
     dplyr::mutate(
-      total = sum(.data$value),
+      # Get total value over all locations
+      total = sum(.data$value), 
       perc = round((.data$value / .data$total) * 100, 2)
     )
   if (response_type == "cumulative")
     summaryData <- summaryData %>%
-      dplyr::group_by(.data$location) %>%
-      dplyr::mutate(
-        value = cumsum(.data$value)
-      )
-  
-  if (x_include_missing) {
-    
-    allYears <- seq(
-      from = min(years),
-      to = max(years),
-      by = 1)
-    missingData <- data.frame(
-      first_observed = allYears[!allYears %in% summaryData$first_observed],
-      location = unique(summaryData$location)[1],
-      value = 0,
-      total = 0,
-      perc = 0
+    dplyr::group_by(.data$location) %>%
+    dplyr::mutate(
+      value = cumsum(.data$value)
     )
-    summaryData <- merge(summaryData, missingData, all = TRUE)
-    
+  summaryData <- dplyr::ungroup(summaryData)
+  
+  if (x_include_missing == TRUE) {
+    summaryData <- summaryData %>%
+      # Add missing years / locations with NA values
+      tidyr::complete(
+        first_observed = tidyr::full_seq(.data$first_observed, period = 1),
+        location = unique(plotData$location)
+      ) %>%
+      dplyr::group_by(.data$location)
+    if (response_type == "cumulative") {
+      # Add previous value in missing years
+      summaryData <- summaryData %>%
+        tidyr::fill(
+          dplyr::any_of(c("value", "total", "perc")),
+          .direction = "down"
+        )
+    } else {
+      # Add missing years with 0 values
+      summaryData <- summaryData %>%
+        tidyr::replace_na(list(value = 0L, total = 0L, perc = 0))
+    }
+    summaryData <- summaryData %>%
+      dplyr::ungroup() %>%
+      dplyr::arrange(.data$first_observed)
   }
-
+  
   # For optimal displaying in the plot
   summaryData$location <- as.factor(summaryData$location)
-  summaryData$location <- factor(summaryData$location, levels = rev(levels(summaryData$location)))
+  summaryData$location <- factor(
+    summaryData$location,
+    levels = rev(levels(summaryData$location))
+  )
   summaryData$first_observed <- as.factor(summaryData$first_observed)
-
-
-
+  
+  
+  
   # Create plot
-
+  
   if (response_type == "relative") {
     position <- "fill"
     text <- paste0(summaryData$location, 
-      "<br>", y_lab, ": ", summaryData$perc, "%", 
-      "<br>", x_lab, ": ", summaryData$first_observed)
+                   "<br>", y_lab, ": ", summaryData$perc, "%", 
+                   "<br>", x_lab, ": ", summaryData$first_observed)
   } else {
     position <- "stack"
     text <- paste0(summaryData$location, 
-      "<br>", y_lab, ": ", summaryData$value, 
-      "<br>", x_lab, ": ", summaryData$first_observed)
+                   "<br>", y_lab, ": ", summaryData$value, 
+                   "<br>", x_lab, ": ", summaryData$first_observed)
   }
-
+  
   pl <- ggplot2::ggplot(data = summaryData, ggplot2::aes(
     x = .data$first_observed,
     y = .data$value,
@@ -235,17 +271,20 @@ indicator_native_range_year <- function(
       breaks = nice_seq(
         start_year = min(years, na.rm = TRUE),
         end_year = max(years, na.rm = TRUE),
-        step_size = x_major_scale_stepsize
+        step_size = min(
+          x_major_scale_stepsize,
+          max(years, na.rm = TRUE) - min(years, na.rm = TRUE) + 1
+        )
       )
     ) +
     ggplot2::xlab(x_lab) +
     ggplot2::ylab(y_lab) +
     ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5))
-
+  
   if (response_type == "relative") {
     pl <- pl + ggplot2::scale_y_continuous(labels = scales::percent_format())
   }
-
+  
   pl_2 <- plotly::ggplotly(data = summaryData, pl, tooltip = "text") %>%
     plotly::layout(
       xaxis = list(title = x_lab, tickangle = "auto"),
@@ -253,14 +292,14 @@ indicator_native_range_year <- function(
       margin = list(b = 80, t = 100),
       barmode = ifelse(nlevels(summaryData$first_observed) == 1, "group", "stack")
     )
-
+  
   # To prevent warnings in UI
   pl_2$elementId <- NULL
-
+  
   # Change variable name
   names(summaryData)[names(summaryData) == "value"] <- "n"
   names(summaryData)[names(summaryData) == "first_observed"] <- "year"
   names(summaryData)[names(summaryData) == "location"] <- "native_range"
-
+  
   return(list(static_plot = pl, interactive_plot = pl_2, data = summaryData))
 }

--- a/R/utils-plots.R
+++ b/R/utils-plots.R
@@ -15,12 +15,9 @@ nice_seq <- function(start_year, end_year, step_size) {
   first_nice_cut <- ceiling(start_year / step_size) * step_size
   nice_cuts <- seq(from = first_nice_cut, to = end_year, by = step_size)
   
-  cuts <- c(
+  c(
     start_year, 
     nice_cuts,
     if (end_year > utils::tail(nice_cuts, n = 1)) end_year 
   )
-  
-  return(cuts)
-  
 }

--- a/R/utils-plots.R
+++ b/R/utils-plots.R
@@ -1,0 +1,26 @@
+#' Generate nice sequence with slightly different cut values compared to \code{\link[base]{seq}}
+#' 
+#' The inner values are forced to be a multiple of the stepsize
+#' 
+#' @param start_year (integer) The min cut value.
+#' @param end_year (integer) The max cut value.
+#' @param step_size (integer) The max distance between two cut values.
+#' 
+#' @return (integer vector) All cut values.
+#' 
+#' @noRd
+nice_seq <- function(start_year, end_year, step_size) {
+  
+  # Calculate the first "nice" cut point (round up to the nearest multiple of step_size)
+  first_nice_cut <- ceiling(start_year / step_size) * step_size
+  nice_cuts <- seq(from = first_nice_cut, to = end_year, by = step_size)
+  
+  cuts <- c(
+    start_year, 
+    nice_cuts,
+    if (end_year > utils::tail(nice_cuts, n = 1)) end_year 
+  )
+  
+  return(cuts)
+  
+}

--- a/man/gbif_verify_keys.Rd
+++ b/man/gbif_verify_keys.Rd
@@ -47,7 +47,7 @@ GBIF Backbone.)
 # input is a vector
 keys1 <- c(
   "12323785387253", # invalid GBIF taxonKey
-  "128545334", # valid taxonKey, not a GBIF Backbone key
+  "194877248", # valid taxonKey, not a GBIF Backbone key
   "1000693", # a GBIF Backbone key, synonym
   "1000310", # a GBIF Backbone key, accepted
   NA, NA

--- a/man/indicator_native_range_year.Rd
+++ b/man/indicator_native_range_year.Rd
@@ -120,7 +120,7 @@ indicator_native_range_year(data, response_type = "cumulative")
 # Include missing years on the x-axis
 indicator_native_range_year(
   data,
-  response_type = "cumulative"
+  response_type = "cumulative",
   x_include_missing = TRUE,
 )
 }

--- a/man/indicator_native_range_year.Rd
+++ b/man/indicator_native_range_year.Rd
@@ -50,8 +50,8 @@ Default: \code{"absolute"}. If "absolute" the number per year and location
 is displayed; if "relative" each bar is standardised per year before stacking;
 if "cumulative" the cumulative number over years per location.}
 
-\item{relative}{(logical) if \code{TRUE} each bar is standardised before
-stacking. Deprecated, use \code{response_type = "relative"} instead.}
+\item{relative}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} (logical) If \code{TRUE} each
+bar is standardised before stacking. Deprecated, use \code{response_type = "relative"} instead.}
 
 \item{taxon_key_col}{character. Name of the column of \code{df} containing
 taxon IDs. Default: \code{"key"}.}
@@ -103,7 +103,25 @@ data <- read_tsv(datafile,
     first_observed = col_double(),
     last_observed = col_double()
   )
+) 
+data <- data[data$locality == "Belgium", ]
+
+# Specify the type of native range we are interested in
+indicator_native_range_year(data, type = "native_continent")
+
+# Specify the years we are interested in
+indicator_native_range_year(data, years = 2010:2013)
+indicator_native_range_year(data, years = c(2010, 2013))
+
+# Specify the response type
+indicator_native_range_year(data, response_type = "relative")
+indicator_native_range_year(data, response_type = "cumulative")
+
+# Include missing years on the x-axis
+indicator_native_range_year(
+  data,
+  response_type = "cumulative"
+  x_include_missing = TRUE,
 )
-indicator_native_range_year(data, "native_continent", years = c(2010,2013))
 }
 }

--- a/man/indicator_native_range_year.Rd
+++ b/man/indicator_native_range_year.Rd
@@ -121,7 +121,7 @@ indicator_native_range_year(data, response_type = "cumulative")
 indicator_native_range_year(
   data,
   response_type = "cumulative",
-  x_include_missing = TRUE,
+  x_include_missing = TRUE
 )
 }
 }

--- a/tests/testthat/test-gbif_verify_keys.R
+++ b/tests/testthat/test-gbif_verify_keys.R
@@ -26,7 +26,8 @@ test_that("test several input types", {
   )
   
   # input df doesn't contain column with name keys
-  expect_error(gbif_verify_keys(data.frame(bad_col_name = 12)),
+  expect_error(
+    gbif_verify_keys(data.frame(bad_col_name = 12)),
     paste(
       "Column with keys not found.",
       "Did you forget maybe to pass",
@@ -38,13 +39,15 @@ test_that("test several input types", {
 
 test_that("output type and content", {
   
-  # basic vector with input keys for tests
+  # basic character vector with input keys for tests
   keys1 <- c(
     "12323785387253", # is not a taxonkey
-    "172331902", # not a taxonKey from Backbone, but kingdom Animalia from CoL
-    "1000693", # is a synonym: Pterodina calcaris Langer, 1909,
+    # not a taxonKey from Backbone, but Cherax destructor from RIPARIAS target
+    # species list
+    "194877248",
+    "1000693", # is a synonym from Backbone: Pterodina calcaris Langer, 1909,
     # Synonym of Testudinella parva (Ternetz, 1892)
-    "1000310", # accepted taxon: Pyrococcus woesei Zillig, 1988
+    "1000310", # accepted taxon from Backbone: Pyrococcus woesei Zillig, 1988
     NA, NA
   )
   
@@ -70,13 +73,10 @@ test_that("output type and content", {
   output2 <- gbif_verify_keys(keys2)
   output3 <- gbif_verify_keys(keys3)
   output4 <- gbif_verify_keys(keys4)
-
+  
   # output expected
   output_keys <- dplyr::tibble(
-    key = c(
-      12323785387253, 172331902,
-      1000693, 1000310
-    ),
+    key = as.numeric(keys1[!is.na(keys1)]),
     is_taxonKey = c(FALSE, TRUE, TRUE, TRUE),
     is_from_gbif_backbone = c(NA, FALSE, TRUE, TRUE),
     is_synonym = c(NA, NA, TRUE, FALSE)
@@ -95,8 +95,8 @@ test_that("output type and content", {
   expect_equal(class(output2), c("tbl_df", "tbl", "data.frame"))
   expect_equal(class(output3), c("tbl_df", "tbl", "data.frame"))
   expect_equal(class(output2), c("tbl_df", "tbl", "data.frame"))
-
-
+  
+  
   # output content is the same for all kinds of inputs
   expect_true(nrow(output1) == nrow(output_keys))
   expect_true(nrow(output2) == nrow(output_keys))
@@ -115,12 +115,14 @@ test_that("function works even with duplicated taxon keys", {
   # basic vector with input keys for tests
   keys_with_duplicates <- c(
     "12323785387253", # is not a taxonkey
-    "172331902", # not a taxonKey from Backbone, but kingdom Animalia from CoL
+    # not a taxonKey from Backbone, but Cherax destructor from RIPARIAS target
+    # species list
+    "194877248",
     "1000693", # is a synonym: Pterodina calcaris Langer, 1909,
     # Synonym of Testudinella parva (Ternetz, 1892)
     "1000310", # accepted taxon: Pyrococcus woesei Zillig, 1988
     "12323785387253", # duplicate
-    "172331902", # duplicate
+    "194877248", # duplicate
     "1000693", # duplicate
     "1000310" # duplicate
   )

--- a/tests/testthat/test-indicator_native_range_year.R
+++ b/tests/testthat/test-indicator_native_range_year.R
@@ -246,7 +246,7 @@ test_that("x_include_missing arg for indicator_native_range", {
     plot_output_relative$data$year %in% missing_years
   ] == 0))
   
-  # When `reponse_type` = "relative", columns `year` and `native_range` of data
+  # When `response_type` = "relative", columns `year` and `native_range` of data
   # slot are still factors
   expect_true(is.factor(plot_output_relative$data$year))
   expect_true(is.factor(plot_output_relative$data$native_range))

--- a/tests/testthat/test-indicator_native_range_year.R
+++ b/tests/testthat/test-indicator_native_range_year.R
@@ -6,10 +6,10 @@ input_test_df <- read.delim(
   sep = "\t"
 )
 
-nrow_no_first_obs <-
-  nrow(input_test_df[is.na(input_test_df$first_observed), ])
-
 cleaned_input_test_df <- input_test_df[!is.na(input_test_df$first_observed), ]
+cleaned_input_test_df <- cleaned_input_test_df[
+  cleaned_input_test_df$locality == "Belgium",
+]
 
 test_that("Arg: df", {
   expect_error(
@@ -40,7 +40,7 @@ test_that("Arg: type", {
 test_that("Arg: years", {
   expect_error(
     indicator_native_range_year(cleaned_input_test_df,
-      years = "2000"
+                                years = "2000"
     ),
     "Argument years has to be a number."
   )
@@ -54,22 +54,22 @@ test_that("Arg: years", {
 
 
 test_that("Arg: x_major_scale_stepsize", {
-    expect_error(
-      indicator_native_range_year(cleaned_input_test_df,
-        x_major_scale_stepsize = "10"
-      ),
-      "Argument x_major_scale_stepsize has to be a number."
-    )
-  })
+  expect_error(
+    indicator_native_range_year(cleaned_input_test_df,
+                                x_major_scale_stepsize = "10"
+    ),
+    "Argument x_major_scale_stepsize has to be a number."
+  )
+})
 
 test_that("Arg: x_include_missing", {
-    expect_error(
-      indicator_native_range_year(cleaned_input_test_df,
-        x_include_missing = "TRUE"
-      ),
-      "Argument x_include_missing has to be a logical."
-    )
-  })
+  expect_error(
+    indicator_native_range_year(cleaned_input_test_df,
+                                x_include_missing = "TRUE"
+    ),
+    "Argument x_include_missing has to be a logical."
+  )
+})
 
 test_that("Arg: first_observed", {
   expect_error(
@@ -106,25 +106,25 @@ test_that("Test output type, class, slots and columns", {
   nRecords <- nrow(unique(invasive_df[, c("last_observed", "native_range")]))
   plot_output_invasive <- indicator_native_range_year(invasive_df)
   expect_equal(nrow(plot_output_invasive$data), nRecords)  
-    
+  
   # Otherwise too many entries in legend
   cleaned_input_test_df <- cleaned_input_test_df[grepl("america", cleaned_input_test_df$native_range, ignore.case = TRUE), ]
   
   plot_output_list <- list(
     # absolute
     absolute = indicator_native_range_year(df = cleaned_input_test_df,
-                                years = c(2000, 2005)
-                            ),
+                                           years = c(2000, 2005)
+    ),
     # relative                                
     relative = indicator_native_range_year(df = cleaned_input_test_df,
-                                years = c(2000, 2005),
-                                response_type = "relative"
-                            ),
+                                           years = c(2000, 2005),
+                                           response_type = "relative"
+    ),
     # cumulative
     cumulative = indicator_native_range_year(df = cleaned_input_test_df,
-                                years = c(2000, 2005),
-                                response_type = "cumulative"
-                            )
+                                             years = c(2000, 2005),
+                                             response_type = "cumulative"
+    )
   )
   
   # data slot is not affected by value of related arg
@@ -153,21 +153,21 @@ test_that("Test output type, class, slots and columns", {
     expect_type(plot_output$data, type = "list")
     expect_s3_class(plot_output$data, class = c("data.frame", "tbl_df"))
     
-    # data contains only columns year, native_range, n, total and perc in this
-    # order
+    # data contains only columns `year`, `native_range`, `n`, `total` and `perc`
+    # in this order
     expect_equal(
       names(plot_output$data),
       c("year", "native_range", "n", "total", "perc"),
       info = response_type
     )
     
-    # columns year and native_range of data slot are factors
+    # columns `year` and `native_range` of data slot are factors
     expect_true(is.factor(plot_output$data$year), info = response_type)
     expect_true(is.factor(plot_output$data$native_range), info = response_type)
-    # columns n and total of data slot are integers
+    # columns `n` and total of data slot are integers
     expect_true(is.integer(plot_output$data$n), info = response_type)
     expect_true(is.integer(plot_output$data$total), info = response_type)
-    # column perc of data slot is double
+    # column `perc` of data slot is double
     expect_true(is.double(plot_output$data$perc), info = response_type)
     
   }
@@ -175,40 +175,125 @@ test_that("Test output type, class, slots and columns", {
 })
 
 test_that("x_include_missing arg for indicator_native_range", {
+  # For brevity we perform general checks with `response_type` = "absolute"
+  # only
+  plot_output_absolute <- indicator_native_range_year(
+    df = cleaned_input_test_df,
+    response_type = "absolute",
+    x_include_missing = TRUE
+  )
   
-    plot_output <- indicator_native_range_year(
-      df = cleaned_input_test_df,
-      years = c(2000, 2005),
-      x_include_missing = TRUE
-    )
-    
-    # output is a list
-    expect_type(plot_output, type = "list")
-    
-    # static plot slot is a list with gg as class
-    expect_type(plot_output$static_plot, type = "list")
-    expect_s3_class(plot_output$static_plot, class = c("gg", "ggplot"))
-    
-    # interactive plot slot is a list with plotly and htmlwidget as class
-    expect_type(plot_output$interactive_plot, type = "list")
-    expect_s3_class(plot_output$interactive_plot, class = c("plotly", "htmlwidget"))
-    
-    # data is a data.frame (tibble)
-    expect_type(plot_output$data, type = "list")
-    expect_s3_class(plot_output$data, class = c("data.frame", "tbl_df"))
+  # output is a list
+  expect_type(plot_output_absolute, type = "list")
   
-  })
-
-
-test_that("relative arg is deprecated", {
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      expect_warning(
-        indicator_native_range_year(
-          df = cleaned_input_test_df,
-          years = c(2000, 2005),
-          relative = TRUE
+  # static plot slot is a list with gg as class
+  expect_type(plot_output_absolute$static_plot, type = "list")
+  expect_s3_class(plot_output_absolute$static_plot, class = c("gg", "ggplot"))
+  
+  # interactive plot slot is a list with plotly and htmlwidget as class
+  expect_type(plot_output_absolute$interactive_plot, type = "list")
+  expect_s3_class(
+    plot_output_absolute$interactive_plot,
+    class = c("plotly", "htmlwidget")
+  )
+  
+  # `data` is a data.frame (tibble)
+  expect_type(plot_output_absolute$data, type = "list")
+  expect_s3_class(
+    plot_output_absolute$data,
+    class = c("data.frame", "tbl_df")
+  )
+  
+  # `data` contains only columns `year`, `native_range`, `n`, `total` and `perc`
+  expect_equal(
+    names(plot_output_absolute$data),
+    c("year", "native_range", "n", "total", "perc")
+  )
+  
+  # columns `year` and `native_range` of data slot are factors
+  expect_true(is.factor(plot_output_absolute$data$year))
+  expect_true(is.factor(plot_output_absolute$data$native_range))
+  # columns `n` and `total` of data slot are integers
+  expect_true(is.integer(plot_output_absolute$data$n))
+  expect_true(is.integer(plot_output_absolute$data$total))
+  
+  # Non general checks start here
+  
+  # `n` is 0 for missing years
+  missing_years <- plot_output_absolute$data$year[
+    !(plot_output_absolute$data$year %in% 
+        cleaned_input_test_df$first_observed)
+  ]
+  expect_true(all(plot_output_absolute$data$n[
+    plot_output_absolute$data$year %in% missing_years
+  ] == 0))
+  
+  # `n` is 0 for missing years when `response_type` = "relative". Also,
+  # same missing years as for absolute output
+  plot_output_relative <- indicator_native_range_year(
+    df = cleaned_input_test_df,
+    response_type = "relative",
+    x_include_missing = TRUE
+  )
+  expect_identical(
+    missing_years,
+    plot_output_relative$data$year[
+      !(plot_output_relative$data$year %in% 
+          cleaned_input_test_df$first_observed)
+    ]
+  )
+  expect_true(all(plot_output_relative$data$n[
+    plot_output_relative$data$year %in% missing_years
+  ] == 0))
+  
+  # When `reponse_type` = "relative", columns `year` and `native_range` of data
+  # slot are still factors
+  expect_true(is.factor(plot_output_relative$data$year))
+  expect_true(is.factor(plot_output_relative$data$native_range))
+  # Columns `n` and `total` of data slot are still integers
+  expect_true(is.integer(plot_output_relative$data$n))
+  expect_true(is.integer(plot_output_relative$data$total))
+  
+  # n is always equal or greater than previous year if `response_type` =
+  # "cumulative" and same missing years
+  plot_output_cumulative <- indicator_native_range_year(
+    df = cleaned_input_test_df,
+    response_type = "cumulative",
+    x_include_missing = TRUE
+  )
+  expect_identical(
+    missing_years,
+    plot_output_cumulative$data$year[
+      !(plot_output_cumulative$data$year %in% 
+          cleaned_input_test_df$first_observed)
+    ]
+  )
+  testthat::expect_true(
+    all(
+      unlist(
+        lapply(
+          split(plot_output_cumulative$data, 
+                f = plot_output_cumulative$data$native_range),
+          function(x) all(diff(x$n) >= 0)
         )
       )
     )
-  })
+  )
+  
+  # When `response_type` = "cumulative", columns `year` and `native_range` of
+  # data slot are still factors
+  expect_true(is.factor(plot_output_cumulative$data$year))
+  expect_true(is.factor(plot_output_cumulative$data$native_range))
+  # Columns `n` and `total` of data slot are still integers
+  expect_true(is.integer(plot_output_cumulative$data$n))
+  expect_true(is.integer(plot_output_cumulative$data$total))
+})
+
+test_that("relative arg is deprecated", {
+  lifecycle::expect_deprecated(
+      indicator_native_range_year(
+        df = cleaned_input_test_df,
+        years = c(2000, 2005),
+        relative = TRUE
+  ))
+})


### PR DESCRIPTION
This pull request updates the `indicator_native_range_year()` function and related documentation and tests to fix a bug (#166) when using cumulative response type with missing years, improve documentation, and extend unit tests. The changes ensure that missing years are handled correctly for all response types, especially "cumulative", and add more robust testing and examples. Minor improvements for `gbif_verify_keys()` as well.

### Bug fix and feature improvements

* Fixed a bug in `indicator_native_range_year()` where missing years were not handled correctly for `response_type = "cumulative"` and `x_include_missing = TRUE`. Now, missing years are filled appropriately for all response types, with cumulative values carried forward as expected.
* Improved the logic for determining x-axis scale steps to better handle cases with a small range of years.
* Moved help function `nice_seq()` to a new file, `utils-plots.R` as it is used by two different functions. Help functions should be stored separately, especially if they are used by more than one function.
* Improve `gbif_verify_keys()`: use `message()` instead of `print()`, use is.null() instead of is.character to check if a key is a valid taxon key. Probably changed behavior of dependencies behind or output returned by GBIF.

### Documentation updates

* Added more examples to the documentation for `indicator_native_range_year()`, including specifying native range type, years, response type, and handling missing years. Deprecated argument `relative` is now clearly marked as deprecated via lifecycle badge in documentation.
* Updated one key in vector of keys in example of `gbif_verify_keys()`. A not valid taxon key from CoL checklist seems defunct now. Used a key from one of our  "stable" checklists.

### Unit test improvements

* Extended unit tests for `indicator_native_range_year()` to check correct handling of missing years for all response types, factor and integer column types, and cumulative behavior. Deprecated argument warnings are now checked using `lifecycle::expect_deprecated`.
* Updated tests for `gbif_verify_keys()`.

### Package metadata

* Bumped package version from `3.1.0` to `3.1.1` to reflect these changes.
* Updated `NEWS.md` to summarize the bug fix and documentation improvements.