### PR TITLE
Add date-released

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,6 @@ type: software
 license: MIT
 title: 'trias: Process Data for the Project Tracking Invasive Alien Species (TrIAS)'
 version: 3.2.4
-doi: 10.32614/CRAN.package.trias
 abstract: R package to provide functionality to facilitate the data processing for
   the project Tracking Invasive Alien Species (TrIAS <https://trias-project.be>).
 authors:
@@ -29,7 +28,6 @@ authors:
   given-names: Machteld
   email: machteld.varewyck@openanalytics.eu
   orcid: https://orcid.org/0009-0003-0496-0447
-repository: https://inbo.r-universe.dev/
 repository-code: https://github.com/trias-project/trias
 url: https://trias-project.github.io/trias
 date-released: '2026-04-22'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,6 +32,7 @@ authors:
 repository: https://inbo.r-universe.dev/
 repository-code: https://github.com/trias-project/trias
 url: https://trias-project.github.io/trias
+date-released: '2026-04-22'
 contact:
 - family-names: Oldoni
   given-names: Damiano

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,6 +2,7 @@ Package: trias
 Title: Process Data for the Project Tracking Invasive Alien Species
     (TrIAS)
 Version: 3.2.4
+Date: 2026-04-22
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562")),


### PR DESCRIPTION
This PR completes the previous PR #192: by adding `Date:` field in `DESCRIPTION`, the `date-released` field in `CITATION.cff` appears. In this way the year will correctly appear in citation. 